### PR TITLE
textfieldをiconに対応・textareaでの縦リサイズを有効化

### DIFF
--- a/packages/textfield/_mixins.scss
+++ b/packages/textfield/_mixins.scss
@@ -37,6 +37,18 @@
     }
   }
 
+    &.-icon-before {
+      ._icon {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+      }
+    }
+
   textarea._input {
     resize: vertical;
   }
@@ -162,6 +174,20 @@
       );
     }
   }
+
+  ._icon {
+    color: adapter.get-field-text-color(
+      $color: $intention,
+      $state: enabled
+    );
+
+    @include -disabled-rule {
+      color: adapter.get-field-text-color(
+        $color: $intention,
+        $state: disabled
+      );
+    }
+  }
 }
 
 @mixin -size-rule($level: m) {
@@ -176,6 +202,23 @@
   textarea._input {
     min-height: adapter.get-interactive-component-height($level: $level);
     line-height: adapter.get-line-height($level: $level, $density: normal);
+  }
+
+  &.-icon-before ._input {
+    @if $level == s {
+      padding-left: #{adapter.get-spacing-size($level: xs) + adapter.get-font-size($level: m) + adapter.get-spacing-size($level: xs)};
+    } @else if $level == m {
+      padding-left: #{adapter.get-spacing-size($level: s) + adapter.get-font-size($level: m) + adapter.get-spacing-size($level: xs)};
+    } @else if $level == l {
+      padding-left: #{adapter.get-spacing-size($level: m) + adapter.get-font-size($level: m) + adapter.get-spacing-size($level: xs)};
+    }
+  }
+
+  &.-icon-before ._icon {
+    left: adapter.get-spacing-size($level: s);
+    width: adapter.get-font-size($level: $level);
+    height: adapter.get-interactive-component-height($level: $level);
+    font-size: adapter.get-font-size($level: $level);
   }
 }
 

--- a/packages/textfield/_mixins.scss
+++ b/packages/textfield/_mixins.scss
@@ -261,7 +261,7 @@
     }
   } @else if $appearance == filled {
     ._input {
-      border-radius: 0;
+      border-radius: adapter.get-radius-size($level: m) adapter.get-radius-size($level: m) 0 0;
       box-shadow: inset 0 #{0 - adapter.get-border-size($level: m)} 0 0 #{adapter.get-field-border-color(
           $color: $intention,
           $state: enabled

--- a/packages/textfield/_mixins.scss
+++ b/packages/textfield/_mixins.scss
@@ -38,8 +38,7 @@
   }
 
   textarea._input {
-    height: auto !important;
-    font-family: inherit;
+    resize: vertical;
   }
 
   // width
@@ -172,6 +171,11 @@
       (adapter.get-line-height($level: $level, $density: normal) * 0.5)}
       adapter.get-spacing-size($level: $level);
     font-size: adapter.get-font-size($level: $level);
+  }
+
+  textarea._input {
+    min-height: adapter.get-interactive-component-height($level: $level);
+    line-height: adapter.get-line-height($level: $level, $density: normal);
   }
 }
 


### PR DESCRIPTION
- textfieldにiconを配置したパターンのための指定を追加しました
- textarea要素でマークアップしたときに縦方向のリサイズが効かなかったので有効化しました

|appearance: outlined|appearance: filled|resize textarea|
|:--:|:--:|:--:|
|<img width="300" alt="outlined" src="https://github.com/pepabo/inhouse-components-web/assets/42428172/95e5fbbb-24c6-4bec-856d-d1054d8f57fa">|<img width="300" alt="filled" src="https://github.com/pepabo/inhouse-components-web/assets/42428172/7d752b10-5571-4bc4-bace-f6f967017516">|<img width="300" alt="image: resize textarea" src="https://github.com/pepabo/inhouse-components-web/assets/42428172/a1a5715d-2d2e-42e6-8dca-e8dd20f4b37c">|

