### PR TITLE
select/textfieldのcolor, bg-color, opacityを変更

### DIFF
--- a/packages/select/_mixins.scss
+++ b/packages/select/_mixins.scss
@@ -29,10 +29,6 @@
     transition: adapter.get-transition-value();
     appearance: none;
 
-    @include -focus-rule {
-      background-color: adapter.get-primitive-color($name: white) !important;
-    }
-
     @include -disabled-rule {
       cursor: not-allowed;
       opacity: adapter.get-disabled-surface-opacity();

--- a/packages/select/_mixins.scss
+++ b/packages/select/_mixins.scss
@@ -170,6 +170,7 @@
 @mixin -appearance-rule($appearance: outlined, $intention: neutral) {
   @if $appearance == outlined {
     ._select {
+      background-color: adapter.get-surface-color($brightness: light, $priority: primary);
       border-radius: adapter.get-radius-size($level: m);
       box-shadow: inset 0 0 0 #{adapter.get-border-size($level: m)} #{adapter.get-field-border-color(
           $color: $intention,
@@ -199,7 +200,8 @@
     }
   } @else if $appearance == filled {
     ._select {
-      border-radius: 0;
+      background-color: adapter.get-surface-color($brightness: light, $priority: tertiary);
+      border-radius: adapter.get-radius-size($level: m) adapter.get-radius-size($level: m) 0 0;
       box-shadow: inset 0 #{0 - adapter.get-border-size($level: m)} 0 0 #{adapter.get-field-border-color($color: $intention, $state: enabled)};
 
       @include -hover-rule {

--- a/packages/select/_mixins.scss
+++ b/packages/select/_mixins.scss
@@ -35,6 +35,11 @@
 
     @include -disabled-rule {
       cursor: not-allowed;
+      opacity: adapter.get-disabled-surface-opacity();
+
+      & + ._icon {
+        opacity: adapter.get-disabled-surface-opacity();
+      }
     }
   }
 
@@ -137,46 +142,11 @@
 
 @mixin -color-rule($intention: neutral) {
   ._select {
-    color: adapter.get-field-text-color(
-      $color: $intention,
-      $state: enabled
-    );
-    background-color: adapter.get-field-surface-color(
-      $color: $intention,
-      $state: enabled
-    );
-
-    @include -hover-rule {
-      background-color: adapter.get-field-surface-color(
-        $color: $intention,
-        $state: hover
-      );
-    }
-
-    @include -disabled-rule {
-      color: adapter.get-field-text-color(
-        $color: $intention,
-        $state: disabled
-      );
-      background-color: adapter.get-field-surface-color(
-        $color: $intention,
-        $state: disabled
-      );
-
-      & + ._icon {
-        background-color: adapter.get-field-text-color(
-          $color: $intention,
-          $state: disabled
-        );
-      }
-    }
+    color: adapter.get-text-color($brightness: light, $name: high_emphasis);
   }
 
   ._icon {
-    background-color: adapter.get-field-text-color(
-      $color: $intention,
-      $state: enabled
-    );
+    background-color: adapter.get-text-color($brightness: light, $name: high_emphasis);
   }
 }
 
@@ -226,13 +196,6 @@
                 )
             )};
       }
-
-      @include -disabled-rule {
-        box-shadow: inset 0 0 0 #{adapter.get-border-size($level: m)} #{adapter.get-field-border-color(
-            $color: $intention,
-            $state: disabled
-          )};
-      }
     }
   } @else if $appearance == filled {
     ._select {
@@ -245,10 +208,6 @@
 
       @include -focus-rule {
         box-shadow: inset 0 #{0 - adapter.get-border-size($level: m)} 0 0 #{adapter.get-field-border-color($color: $intention, $state: focused)}, #{adapter.get-focus-ring-box-shadow($color: adapter.get-field-border-color($color: $intention, $state: focused))};
-      }
-
-      @include -disabled-rule {
-        box-shadow: inset 0 #{0 - adapter.get-border-size($level: m)} 0 0 #{adapter.get-field-border-color($color: $intention, $state: disabled)};
       }
     }
   }

--- a/packages/textfield/_mixins.scss
+++ b/packages/textfield/_mixins.scss
@@ -156,6 +156,7 @@
 @mixin -color-rule($intention: neutral) {
   ._input {
     color: adapter.get-text-color($brightness: light, $name: high_emphasis);
+    background-color: adapter.get-surface-color($brightness: light, $priority: tertiary);
 
     &::placeholder {
       color: adapter.get-text-color($brightness: light, $name: low_emphasis);
@@ -202,6 +203,7 @@
 @mixin -appearance-rule($appearance: outlined, $intention: neutral) {
   @if $appearance == outlined {
     ._input {
+      background-color: adapter.get-surface-color($brightness: light, $priority: primary);
       border-radius: adapter.get-radius-size($level: m);
       box-shadow: inset 0 0 0 #{adapter.get-border-size($level: m)} #{adapter.get-field-border-color(
           $color: $intention,
@@ -231,6 +233,7 @@
     }
   } @else if $appearance == filled {
     ._input {
+      background-color: adapter.get-surface-color($brightness: light, $priority: tertiary);
       border-radius: adapter.get-radius-size($level: m) adapter.get-radius-size($level: m) 0 0;
       box-shadow: inset 0 #{0 - adapter.get-border-size($level: m)} 0 0 #{adapter.get-field-border-color(
           $color: $intention,

--- a/packages/textfield/_mixins.scss
+++ b/packages/textfield/_mixins.scss
@@ -32,10 +32,6 @@
       cursor: text;
     }
 
-    @include -focus-rule {
-      background-color: adapter.get-primitive-color($name: white) !important;
-    }
-
     @include -disabled-rule {
       opacity: adapter.get-disabled-surface-opacity();
 

--- a/packages/textfield/_mixins.scss
+++ b/packages/textfield/_mixins.scss
@@ -35,19 +35,27 @@
     @include -focus-rule {
       background-color: adapter.get-primitive-color($name: white) !important;
     }
-  }
 
-    &.-icon-before {
-      ._icon {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        pointer-events: none;
+    @include -disabled-rule {
+      opacity: adapter.get-disabled-surface-opacity();
+
+      & + ._icon {
+        opacity: adapter.get-disabled-surface-opacity();
       }
     }
+  }
+
+  &.-icon-before {
+    ._icon {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      pointer-events: none;
+    }
+  }
 
   textarea._input {
     resize: vertical;
@@ -147,46 +155,15 @@
 
 @mixin -color-rule($intention: neutral) {
   ._input {
-    color: adapter.get-field-text-color(
-      $color: $intention,
-      $state: enabled
-    );
-    background-color: adapter.get-field-surface-color(
-      $color: $intention,
-      $state: enabled
-    );
+    color: adapter.get-text-color($brightness: light, $name: high_emphasis);
 
-    @include -hover-rule {
-      background-color: adapter.get-field-surface-color(
-        $color: $intention,
-        $state: hover
-      );
-    }
-
-    @include -disabled-rule {
-      color: adapter.get-field-text-color(
-        $color: $intention,
-        $state: disabled
-      );
-      background-color: adapter.get-field-surface-color(
-        $color: $intention,
-        $state: disabled
-      );
+    &::placeholder {
+      color: adapter.get-text-color($brightness: light, $name: low_emphasis);
     }
   }
 
   ._icon {
-    color: adapter.get-field-text-color(
-      $color: $intention,
-      $state: enabled
-    );
-
-    @include -disabled-rule {
-      color: adapter.get-field-text-color(
-        $color: $intention,
-        $state: disabled
-      );
-    }
+    color: adapter.get-text-color($brightness: light, $name: high_emphasis);
   }
 }
 
@@ -251,13 +228,6 @@
                 )
             )};
       }
-
-      @include -disabled-rule {
-        box-shadow: inset 0 0 0 #{adapter.get-border-size($level: m)} #{adapter.get-field-border-color(
-            $color: $intention,
-            $state: disabled
-          )};
-      }
     }
   } @else if $appearance == filled {
     ._input {
@@ -286,13 +256,6 @@
                   $state: focused
                 )
             )};
-      }
-
-      @include -disabled-rule {
-        box-shadow: inset 0 #{0 - adapter.get-border-size($level: m)} 0 0 #{adapter.get-field-border-color(
-            $color: $intention,
-            $state: disabled
-          )};
       }
     }
   }


### PR DESCRIPTION
NotionのInhouseコンポーネントガイドライン (Textfield) にしたがって、selectとtextfieldのスタイルを変更しました。
- colorとbackground-colorはstateが変化しても同じ色のまま。
- borderとfocus-ringにstateの変化が現れる。disabledでは全体のopacityが薄くなる。

### Select

|neutral|negative|
|:--:|:--:|
|<img width="300" alt="neutralカラーのenabled, hover, focused, disabledステートごとのSelectコンポーネントが並んだ画像。上段にoutlined、下段にfilledアピアランスが配置されている。" src="https://github.com/pepabo/inhouse-components-web/assets/42428172/e314a840-aa3f-4437-bf1f-8c59e5eb63ae">|<img width="300" alt="negativeカラーのenabled, hover, focused, disabledステートごとのSelectコンポーネントが並んだ画像。上段にoutlined、下段にfilledアピアランスが配置されている。" src="https://github.com/pepabo/inhouse-components-web/assets/42428172/c2578096-a487-473b-bf9c-f24236bff234">|


### TextField

|neutral|negative|
|:--:|:--:|
|<img width="300" alt="neutralカラーのenabled, hover, focused, disabledステートごとのTextFieldコンポーネントが並んだ画像。左にoutlined、右にfilledアピアランスが配置されている。" src="https://github.com/pepabo/inhouse-components-web/assets/42428172/4434f1c9-e60e-4df7-8bfe-814e15b23060">|<img width="300" alt="negativeカラーのenabled, hover, focused, disabledステートごとのTextFieldコンポーネントが並んだ画像。左にoutlined、右にfilledアピアランスが配置されている。" src="https://github.com/pepabo/inhouse-components-web/assets/42428172/5b605b2c-05a5-40f0-9a8e-e2eaa0993b98">|
