### PR TITLE
containerをmixinベースのスタイリングに対応

### DIFF
--- a/packages/container/_mixins.scss
+++ b/packages/container/_mixins.scss
@@ -3,8 +3,11 @@
 @use "@pepabo-inhouse/adapter/mixins" as adapter-mixins;
 @use "@pepabo-inhouse/adapter/functions" as adapter-functions;
 @use "./functions";
+@use "./variables";
 
-@mixin style() {
+@mixin style($options: variables.$default-option) {
+  $options: map.merge(variables.$default-option, $options);
+
   box-sizing: border-box;
   width: 100%;
   margin-right: auto;
@@ -21,9 +24,11 @@
 
   @each $content-size in adapter-functions.get-content-sizes() {
     &.-size-#{$content-size} {
-      max-width: adapter-functions.get-content-size($level: $content-size);
+      @include -size-rule($size: $content-size);
     }
   }
+
+  @include -size-rule($size: map.get($options, size));
 
   &.-is-gapless {
     padding-right: 0;
@@ -35,4 +40,8 @@
   .in-container {
     @include style;
   }
+}
+
+@mixin -size-rule($size: m) {
+  max-width: adapter-functions.get-content-size($level: $size);
 }

--- a/packages/container/_mixins.scss
+++ b/packages/container/_mixins.scss
@@ -15,10 +15,14 @@
   padding-right: functions.get-horizontal-gap(adapter-functions.get-boundary-size-first-key());
   padding-left: functions.get-horizontal-gap(adapter-functions.get-boundary-size-first-key());
 
-  @each $boundary-size-level in adapter-functions.get-boundary-sizes() {
-    @include adapter-mixins.mq-boundary(up, $boundary-size-level) {
-      padding-right: functions.get-horizontal-gap($boundary-size-level);
-      padding-left: functions.get-horizontal-gap($boundary-size-level);
+  @if map.get($options, gapless) == true {
+    @include -gapless-rule;
+  } @else {
+    @each $boundary-size-level in adapter-functions.get-boundary-sizes() {
+      @include adapter-mixins.mq-boundary(up, $boundary-size-level) {
+        padding-right: functions.get-horizontal-gap($boundary-size-level);
+        padding-left: functions.get-horizontal-gap($boundary-size-level);
+      }
     }
   }
 
@@ -31,10 +35,8 @@
   @include -size-rule($size: map.get($options, size));
 
   &.-is-gapless {
-    @include -gapless-rule($gapless: true);
+    @include -gapless-rule;
   }
-
-  @include -gapless-rule($gapless: map.get($options, gapless));
 }
 
 @mixin export {
@@ -47,9 +49,7 @@
   max-width: adapter-functions.get-content-size($level: $size);
 }
 
-@mixin -gapless-rule($gapless: false) {
-  @if $gapless {
-    padding-right: 0 !important;
-    padding-left: 0 !important;
-  }
+@mixin -gapless-rule {
+  padding-right: 0;
+  padding-left: 0;
 }

--- a/packages/container/_mixins.scss
+++ b/packages/container/_mixins.scss
@@ -31,9 +31,10 @@
   @include -size-rule($size: map.get($options, size));
 
   &.-is-gapless {
-    padding-right: 0;
-    padding-left: 0;
+    @include -gapless-rule($gapless: true);
   }
+
+  @include -gapless-rule($gapless: map.get($options, gapless));
 }
 
 @mixin export {
@@ -44,4 +45,11 @@
 
 @mixin -size-rule($size: m) {
   max-width: adapter-functions.get-content-size($level: $size);
+}
+
+@mixin -gapless-rule($gapless: false) {
+  @if $gapless {
+    padding-right: 0 !important;
+    padding-left: 0 !important;
+  }
 }

--- a/packages/container/variables.scss
+++ b/packages/container/variables.scss
@@ -1,0 +1,3 @@
+$default-option: (
+  size: m,
+);

--- a/packages/container/variables.scss
+++ b/packages/container/variables.scss
@@ -1,3 +1,4 @@
 $default-option: (
   size: m,
+  gapless: false,
 );


### PR DESCRIPTION
containerがmixinベースの記述に対応してなくてclassベースの記述に限定されていたので、mixinベースでセマンティックなマークアップに対してスタイリングできるようにしました。

```
.document-container {
  @include container.style(
    $options: (
      size: m,
      gapless: false,
    )
  );
}
```