### PR TITLE
gridをCSS grid化しつつmixinベースのスタイリングに対応

### DIFF
--- a/packages/grid/_functions.scss
+++ b/packages/grid/_functions.scss
@@ -4,16 +4,8 @@
 @use "@pepabo-inhouse/adapter/functions" as adapter;
 @use "./variables";
 
-@function get-direction($option) {
-  @return map.get($option, direction);
-}
-
 @function compose-col-horizontal-gap($boundary-size-level) {
   @return -get-gap($boundary-size-level);
-}
-
-@function get-col-width($count) {
-  @return percentage(math.div($count, variables.$total-col-count));
 }
 
 @function -get-gap($boundary-size-level) {

--- a/packages/grid/_functions.scss
+++ b/packages/grid/_functions.scss
@@ -8,20 +8,8 @@
   @return map.get($option, direction);
 }
 
-@function compose-row-top-gap($boundary-size-level) {
-  @return -get-gap($boundary-size-level) * -1;
-}
-
-@function compose-row-horizontal-gap($boundary-size-level) {
-  @return math.div(-get-gap($boundary-size-level), -2);
-}
-
-@function compose-col-top-gap($boundary-size-level) {
-  @return -get-gap($boundary-size-level);
-}
-
 @function compose-col-horizontal-gap($boundary-size-level) {
-  @return -get-gap($boundary-size-level) * 0.5;
+  @return -get-gap($boundary-size-level);
 }
 
 @function get-col-width($count) {

--- a/packages/grid/_mixins.scss
+++ b/packages/grid/_mixins.scss
@@ -7,9 +7,9 @@
 
 @mixin row($options: variables.$default-row-option) {
   $options: map.merge(variables.$default-row-option, $options);
+
   display: grid;
   grid-template-columns: repeat(12, 1fr);
-  gap: functions.compose-col-horizontal-gap(adapter-functions.get-boundary-size-first-key());
   box-sizing: border-box;
 
   @if map.get($options, direction) == ltr {
@@ -18,13 +18,20 @@
     direction: rtl;
   }
 
-  &.-is-gapless {
+  @if map.get($options, is-gapless) == true {
     gap: 0;
+  } @else if map.get($options, is-gapless) == false {
+    gap: functions.compose-col-horizontal-gap(adapter-functions.get-boundary-size-first-key());
+
+    &.-is-gapless {
+      gap: 0;
+    }
   }
 }
 
 @mixin col($options: variables.$default-col-option) {
   $options: map.merge(variables.$default-col-option, $options);
+
   box-sizing: border-box;
   width: 100%;
   max-width: 100%;
@@ -32,32 +39,32 @@
   @for $i from 1 through variables.$total-col-count {
     &.-col-#{$i} {
       @include -col($i);
-    }
-  }
 
-  @for $i from 0 through (variables.$total-col-count - 1) {
-    &.-offset-#{$i} {
-      @include -offset($options, $i);
+      @for $offset from 0 through (variables.$total-col-count - 1) {
+        &.-offset-#{$offset} {
+          @include -col($i, $offset);
+        }
+      }
     }
   }
 
   @each $boundary-size-level in adapter-functions.get-boundary-sizes() {
     @include adapter-mixins.mq-boundary(up, $boundary-size-level) {
-
       @for $i from 1 through variables.$total-col-count {
         &.-col-#{$boundary-size-level}-#{$i} {
           @include -col($i);
-        }
-      }
 
-      @for $i from 0 through (variables.$total-col-count - 1) {
-        &.-offset-#{$boundary-size-level}-#{$i} {
-          @include -offset($options, $i);
+          @for $offset from 0 through (variables.$total-col-count - 1) {
+            &.-offset-#{$boundary-size-level}-#{$offset} {
+              @include -col($i, $offset);
+            }
+          }
         }
       }
     }
   }
-  @include -col($count: map.get($options, count));
+
+  @include -col($count: map.get($options, count), $offset: map.get($options, offset));
 }
 
 @mixin export {
@@ -70,14 +77,10 @@
   }
 }
 
-@mixin -col($count) {
-  grid-column: span $count;
-}
-
-@mixin -offset($options, $count) {
-  @if functions.get-direction($options) == ltr {
-    margin-left: functions.get-col-width($count);
-  } @else if functions.get-direction($options) == rtl {
-    margin-right: functions.get-col-width($count);
+@mixin -col($count, $offset: 0) {
+  @if $offset != null and $offset > 0 {
+    grid-column: ($offset + 1)  / span $count;
+  } @else {
+    grid-column: span $count;
   }
 }

--- a/packages/grid/_mixins.scss
+++ b/packages/grid/_mixins.scss
@@ -8,20 +8,10 @@
 @mixin row($options: variables.$default-option) {
   $options: map.merge(variables.$default-option, $options);
 
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: functions.compose-col-horizontal-gap(adapter-functions.get-boundary-size-first-key());
   box-sizing: border-box;
-  margin-top: functions.compose-row-top-gap(adapter-functions.get-boundary-size-first-key());
-  margin-right: functions.compose-row-horizontal-gap(adapter-functions.get-boundary-size-first-key());
-  margin-left: functions.compose-row-horizontal-gap(adapter-functions.get-boundary-size-first-key());
-
-  @each $boundary-size-level in adapter-functions.get-boundary-sizes() {
-    @include adapter-mixins.mq-boundary(up, $boundary-size-level) {
-      margin-top: functions.compose-row-top-gap($boundary-size-level);
-      margin-right: functions.compose-row-horizontal-gap($boundary-size-level);
-      margin-left: functions.compose-row-horizontal-gap($boundary-size-level);
-    }
-  }
 
   &.-align-items-start {
     align-items: flex-start;
@@ -72,13 +62,9 @@
 
 @mixin col($options: variables.$default-option) {
   $options: map.merge(variables.$default-option, $options);
-  flex-shrink: 0;
   box-sizing: border-box;
   width: 100%;
   max-width: 100%;
-  margin-top: functions.compose-col-top-gap(adapter-functions.get-boundary-size-first-key());
-  padding-right: functions.compose-col-horizontal-gap(adapter-functions.get-boundary-size-first-key());
-  padding-left: functions.compose-col-horizontal-gap(adapter-functions.get-boundary-size-first-key());
 
   @for $i from 1 through variables.$total-col-count {
     &.-col-#{$i} {
@@ -94,9 +80,6 @@
 
   @each $boundary-size-level in adapter-functions.get-boundary-sizes() {
     @include adapter-mixins.mq-boundary(up, $boundary-size-level) {
-      margin-top: functions.compose-col-top-gap($boundary-size-level);
-      padding-right: functions.compose-col-horizontal-gap($boundary-size-level);
-      padding-left: functions.compose-col-horizontal-gap($boundary-size-level);
 
       @for $i from 1 through variables.$total-col-count {
         &.-col-#{$boundary-size-level}-#{$i} {
@@ -125,8 +108,7 @@
 }
 
 @mixin -col($count) {
-  flex: 0 0 auto;
-  width: functions.get-col-width($count);
+  grid-column: span $count;
 }
 
 @mixin -offset($options, $count) {

--- a/packages/grid/_mixins.scss
+++ b/packages/grid/_mixins.scss
@@ -114,11 +114,11 @@
 
   @for $i from 1 through variables.$total-col-count {
     &.-col-#{$i} {
-      @include -col($i);
+      @include -grid-column($i);
 
       @for $offset from 0 through (variables.$total-col-count - 1) {
         &.-offset-#{$offset} {
-          @include -col($i, $offset);
+          @include -grid-column($i, $offset);
         }
       }
     }
@@ -128,11 +128,11 @@
     @include adapter-mixins.mq-boundary(up, $boundary-size-level) {
       @for $i from 1 through variables.$total-col-count {
         &.-col-#{$boundary-size-level}-#{$i} {
-          @include -col($i);
+          @include -grid-column($i);
 
           @for $offset from 0 through (variables.$total-col-count - 1) {
             &.-offset-#{$boundary-size-level}-#{$offset} {
-              @include -col($i, $offset);
+              @include -grid-column($i, $offset);
             }
           }
         }
@@ -140,7 +140,7 @@
     }
   }
 
-  @include -col($count: map.get($options, count), $offset: map.get($options, offset));
+  @include -grid-column($count: map.get($options, count), $offset: map.get($options, offset));
 }
 
 @mixin export {
@@ -153,7 +153,7 @@
   }
 }
 
-@mixin -col($count, $offset: 0) {
+@mixin -grid-column($count, $offset: 0) {
   @if $offset != null and $offset > 0 {
     grid-column: ($offset + 1)  / span $count;
   } @else {

--- a/packages/grid/_mixins.scss
+++ b/packages/grid/_mixins.scss
@@ -27,6 +27,82 @@
       gap: 0;
     }
   }
+
+  @if map.get($options, align-content) == start {
+    align-content: start;
+  } @else if map.get($options, align-content) == end {
+    align-content: end;
+  } @else if map.get($options, align-content) == center {
+    align-content: center;
+  } @else if map.get($options, align-content) == stretch {
+    align-content: stretch;
+  } @else if map.get($options, align-content) == space-around {
+    align-content: space-around;
+  } @else if map.get($options, align-content) == space-between {
+    align-content: space-between;
+  }
+
+  &.-align-content-start {
+    align-content: start;
+  }
+
+  &.-align-content-end {
+    align-content: end;
+  }
+
+  &.-align-content-center {
+    align-content: center;
+  }
+
+  &.-align-content-stretch {
+    align-content: stretch;
+  }
+
+  &.-align-content-space-around {
+    align-content: space-around;
+  }
+
+  &.-align-content-space-between {
+    align-content: space-between;
+  }
+
+  @if map.get($options, justify-content) == start {
+    justify-content: start;
+  } @else if map.get($options, justify-content) == end {
+    justify-content: end;
+  } @else if map.get($options, justify-content) == center {
+    justify-content: center;
+  } @else if map.get($options, justify-content) == stretch {
+    justify-content: stretch;
+  } @else if map.get($options, justify-content) == space-around {
+    justify-content: space-around;
+  } @else if map.get($options, justify-content) == space-between {
+    justify-content: space-between;
+  }
+
+  &.-justify-content-start {
+    justify-content: start;
+  }
+
+  &.-justify-content-end {
+    justify-content: end;
+  }
+
+  &.-justify-content-center {
+    justify-content: center;
+  }
+
+  &.-justify-content-stretch {
+    justify-content: stretch;
+  }
+
+  &.-justify-content-space-around {
+    justify-content: space-around;
+  }
+
+  &.-justify-content-space-between {
+    justify-content: space-between;
+  }
 }
 
 @mixin col($options: variables.$default-col-option) {

--- a/packages/grid/_mixins.scss
+++ b/packages/grid/_mixins.scss
@@ -5,8 +5,8 @@
 @use "./variables";
 @use "./functions";
 
-@mixin row($option: variables.$default-option) {
-  $option: map.merge(variables.$default-option, $option);
+@mixin row($options: variables.$default-options) {
+  $options: map.merge(variables.$default-options, $options);
 
   display: flex;
   flex-wrap: wrap;
@@ -70,7 +70,8 @@
   }
 }
 
-@mixin col($option: variables.$default-option) {
+@mixin col($options: variables.$default-options) {
+  $options: map.merge(variables.$default-options, $options);
   flex-shrink: 0;
   box-sizing: border-box;
   width: 100%;
@@ -87,7 +88,7 @@
 
   @for $i from 0 through (variables.$total-col-count - 1) {
     &.-offset-#{$i} {
-      @include -offset($option, $i);
+      @include -offset($options, $i);
     }
   }
 
@@ -105,11 +106,12 @@
 
       @for $i from 0 through (variables.$total-col-count - 1) {
         &.-offset-#{$boundary-size-level}-#{$i} {
-          @include -offset($option, $i);
+          @include -offset($options, $i);
         }
       }
     }
   }
+  @include -col($count: map.get($options, count));
 }
 
 @mixin export {
@@ -127,10 +129,10 @@
   width: functions.get-col-width($count);
 }
 
-@mixin -offset($option, $count) {
-  @if functions.get-direction($option) == ltr {
+@mixin -offset($options, $count) {
+  @if functions.get-direction($options) == ltr {
     margin-left: functions.get-col-width($count);
-  } @else if functions.get-direction($option) == rtl {
+  } @else if functions.get-direction($options) == rtl {
     margin-right: functions.get-col-width($count);
   }
 }

--- a/packages/grid/_mixins.scss
+++ b/packages/grid/_mixins.scss
@@ -5,8 +5,8 @@
 @use "./variables";
 @use "./functions";
 
-@mixin row($options: variables.$default-options) {
-  $options: map.merge(variables.$default-options, $options);
+@mixin row($options: variables.$default-option) {
+  $options: map.merge(variables.$default-option, $options);
 
   display: flex;
   flex-wrap: wrap;
@@ -70,8 +70,8 @@
   }
 }
 
-@mixin col($options: variables.$default-options) {
-  $options: map.merge(variables.$default-options, $options);
+@mixin col($options: variables.$default-option) {
+  $options: map.merge(variables.$default-option, $options);
   flex-shrink: 0;
   box-sizing: border-box;
   width: 100%;

--- a/packages/grid/_mixins.scss
+++ b/packages/grid/_mixins.scss
@@ -5,63 +5,26 @@
 @use "./variables";
 @use "./functions";
 
-@mixin row($options: variables.$default-option) {
-  $options: map.merge(variables.$default-option, $options);
-
+@mixin row($options: variables.$default-row-option) {
+  $options: map.merge(variables.$default-row-option, $options);
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   gap: functions.compose-col-horizontal-gap(adapter-functions.get-boundary-size-first-key());
   box-sizing: border-box;
 
-  &.-align-items-start {
-    align-items: flex-start;
-  }
-
-  &.-align-items-center {
-    align-items: center;
-  }
-
-  &.-align-items-end {
-    align-items: flex-end;
-  }
-
-  &.-align-items-stretch {
-    align-items: stretch;
-  }
-
-  &.-justify-content-start {
-    justify-content: flex-start;
-  }
-
-  &.-justify-content-center {
-    justify-content: center;
-  }
-
-  &.-justify-content-end {
-    justify-content: flex-end;
-  }
-
-  &.-justify-content-around {
-    justify-content: space-around;
-  }
-
-  &.-justify-content-between {
-    justify-content: space-between;
+  @if map.get($options, direction) == ltr {
+    direction: ltr;
+  } @else if map.get($options, direction) == rtl {
+    direction: rtl;
   }
 
   &.-is-gapless {
-    margin: 0;
-    padding: 0;
-
-    > * {
-      margin: 0;
-      padding: 0;
-    }
+    gap: 0;
   }
 }
 
-@mixin col($options: variables.$default-option) {
-  $options: map.merge(variables.$default-option, $options);
+@mixin col($options: variables.$default-col-option) {
+  $options: map.merge(variables.$default-col-option, $options);
   box-sizing: border-box;
   width: 100%;
   max-width: 100%;

--- a/packages/grid/_variables.scss
+++ b/packages/grid/_variables.scss
@@ -6,8 +6,8 @@ $total-col-count: 12;
 $default-row-option: (
   direction: ltr,
   is-gapless: false,
-  justify-content: start,
   align-content: start,
+  justify-content: start,
 );
 
 $default-col-option: (

--- a/packages/grid/_variables.scss
+++ b/packages/grid/_variables.scss
@@ -2,7 +2,9 @@
 @use "sass:map";
 
 $default-option: (
-  direction: ltr
+  direction: ltr,
+  count: 12,
+  size: m,
 );
 
 $total-col-count: 12;

--- a/packages/grid/_variables.scss
+++ b/packages/grid/_variables.scss
@@ -5,7 +5,7 @@ $total-col-count: 12;
 
 $default-row-option: (
   direction: ltr,
-  isGapless: false,
+  is-gapless: false,
   justify-content: start,
   align-content: start,
 );

--- a/packages/grid/_variables.scss
+++ b/packages/grid/_variables.scss
@@ -1,10 +1,16 @@
 @use "sass:list";
 @use "sass:map";
 
-$default-option: (
+$total-col-count: 12;
+
+$default-row-option: (
   direction: ltr,
+  isGapless: false,
+  justify-content: start,
+  align-content: start,
+);
+
+$default-col-option: (
   count: 12,
   size: m,
 );
-
-$total-col-count: 12;


### PR DESCRIPTION
gridモジュールをflexboxからgridプロパティで書き直しつつ、classベースだけでなくmixinベースでセマンティックなマークアップに対してスタイリングできるようにもしました。

```
.multi-pane-wrapper {
  @include in-grid.row();
  & > .contents-pane {
    @include in-grid.col(
      $options: (
        count: 8,
        size: m,
      )
    );
  }
  & > sidebar {
    @include in-grid.col(
      $options: (
        count: 4,
        size: m,
      )
    );
  }
}
```

|result|grid tool|
|:--:|:--:|
|<img width="300" alt="image" src="https://github.com/pepabo/inhouse-components-web/assets/42428172/ff94998d-5f6a-4acc-adb4-91a36b7d9973">|<img width="300" alt="image" src="https://github.com/pepabo/inhouse-components-web/assets/42428172/7f6f0cc0-86f6-4a55-913e-2fb08cea48df">|

## ToTo

- [x] countをmixinベースに対応
- [x] countをgridで書き換える
- [x] offsetをmixinベースに対応

## Icebox
- boundary-sizeの指定をどうするか方針決める
  - gridコンポーネント側で持たなくてもboundaryのadapterあるし使う側でやればいいのでは？な観点