### PR TITLE
Snackbarの追加

### DIFF
--- a/packages/components-web/_index.scss
+++ b/packages/components-web/_index.scss
@@ -21,3 +21,4 @@
 @forward "@pepabo-inhouse/skeleton" as skeleton-*;
 @forward "@pepabo-inhouse/table" as table-*;
 @forward "@pepabo-inhouse/textfield" as textfield-*;
+@forward "@pepabo-inhouse/snackbar" as snackbar-*;

--- a/packages/components-web/inhouse-components-web.scss
+++ b/packages/components-web/inhouse-components-web.scss
@@ -20,6 +20,7 @@
 @use "@pepabo-inhouse/side-navigation";
 @use "@pepabo-inhouse/table";
 @use "@pepabo-inhouse/textfield";
+@use "@pepabo-inhouse/snackbar";
 
 // @import が存在しているので最初に flavor を読む
 // see: https://git.pepabo.com/inhouse/components-web/issues/355
@@ -43,3 +44,4 @@
 @include side-navigation.export;
 @include table.export;
 @include textfield.export;
+@include snackbar.export;

--- a/packages/components-web/package.json
+++ b/packages/components-web/package.json
@@ -39,6 +39,7 @@
     "@pepabo-inhouse/textfield": "^1.0.0",
     "@pepabo-inhouse/thumbnail": "^1.0.0",
     "@pepabo-inhouse/tokens": "^0.14.0",
+    "@pepabo-inhouse/snackbar": "^0.1.0",
     "autoprefixer": "10.4.14",
     "cssnano": "5.1.15",
     "postcss": "8.4.23",

--- a/packages/snackbar/README.md
+++ b/packages/snackbar/README.md
@@ -1,0 +1,13 @@
+# Inhouse Snackbar
+
+## Usage
+
+### Installation
+
+```bash
+$ npm install @pepabo-inhouse/snackbar
+
+# or
+
+$ yarn add @pepabo-inhouse/snackbar
+```

--- a/packages/snackbar/_index.scss
+++ b/packages/snackbar/_index.scss
@@ -1,0 +1,1 @@
+@forward "./mixins" show style, export;

--- a/packages/snackbar/_mixins.scss
+++ b/packages/snackbar/_mixins.scss
@@ -7,17 +7,13 @@
 
   display: flex;
   align-items: center;
-  background-color: adapter.get-semantic-color(map-get($options, color), 100);
-  color: adapter.get-semantic-color(map-get($options, color), 900);
   font-size: adapter.get-font-size(map-get($options, size));
   padding: adapter.get-spacing-size(map-get($options, size));
   gap: adapter.get-spacing-size(map-get($options, size));
   border-radius: adapter.get-radius-size(map-get($options, size));
   box-shadow: adapter.get-elevation-box-shadow(1);
 
-  &.-inline {
-    display: inline-flex;
-  }
+  @include -state-style(map-get($options, color));
 
   &.-color-positive {
     @include -state-style(positive);
@@ -29,6 +25,10 @@
 
   &.-color-notice {
     @include -state-style(notice);
+  }
+
+  &.-inline {
+    display: inline-flex;
   }
 
   ._trailing {

--- a/packages/snackbar/_mixins.scss
+++ b/packages/snackbar/_mixins.scss
@@ -7,8 +7,8 @@
 
   display: flex;
   align-items: center;
-  background-color: adapter.get-semantic-color(map-get($options, intention), map-get($options, background-color-level));
-  color: map-get($options, text-color);
+  background-color: adapter.get-semantic-color(map-get($options, color), 100);
+  color: map-get($options, adapter.get-semantic-color(map-get($options, color), 600));
   font-size: adapter.get-font-size(map-get($options, size));
   padding: adapter.get-spacing-size(map-get($options, size));
   gap: adapter.get-spacing-size(map-get($options, size));

--- a/packages/snackbar/_mixins.scss
+++ b/packages/snackbar/_mixins.scss
@@ -1,0 +1,67 @@
+@use "sass:map";
+@use "@pepabo-inhouse/adapter/functions" as adapter;
+@use "./variables";
+
+@mixin style($options: variables.$default-options) {
+  $options: map.merge(variables.$default-options, $options);
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: adapter.get-semantic-color(map-get($options, intention), map-get($options, background-color-level));
+  color: map-get($options, text-color);
+  font-size: adapter.get-font-size(map-get($options, size));
+  padding: adapter.get-spacing-size(map-get($options, size));
+  gap: adapter.get-spacing-size(map-get($options, size));
+  border-radius: adapter.get-radius-size(map-get($options, size));
+  box-shadow: adapter.get-elevation-box-shadow(1);
+
+  &.-inline {
+    display: inline-flex;
+    justify-content: flex-start;
+  }
+
+  &.-color-positive {
+    @include -state-style(positive);
+  }
+
+  &.-color-negative {
+    @include -state-style(negative);
+  }
+
+  &.-color-notice {
+    @include -state-style(notice);
+  }
+
+  ._group {
+    display: flex;
+    align-items: center;
+    gap: adapter.get-spacing-size(map-get($options, size));
+  }
+
+  ._button {
+    flex-shrink: 0;
+    font-family: inherit;
+    font-size: adapter.get-font-size(map-get($options, size));
+    font-weight: bold;
+    color: map-get($options, button-text-color);
+    border: none;
+    background-color: transparent;
+    cursor: pointer;
+  }
+}
+
+@mixin -state-style($state) {
+  background-color: adapter.get-semantic-color($state, 100);
+  color: adapter.get-semantic-color($state, 800);
+
+  ._button {
+    color: inherit;
+  }
+}
+
+@mixin export {
+  .in-snackbar {
+    @include style;
+  }
+}

--- a/packages/snackbar/_mixins.scss
+++ b/packages/snackbar/_mixins.scss
@@ -8,7 +8,7 @@
   display: flex;
   align-items: center;
   background-color: adapter.get-semantic-color(map-get($options, color), 100);
-  color: map-get($options, adapter.get-semantic-color(map-get($options, color), 600));
+  color: adapter.get-semantic-color(map-get($options, color), 900);
   font-size: adapter.get-font-size(map-get($options, size));
   padding: adapter.get-spacing-size(map-get($options, size));
   gap: adapter.get-spacing-size(map-get($options, size));

--- a/packages/snackbar/_mixins.scss
+++ b/packages/snackbar/_mixins.scss
@@ -7,7 +7,6 @@
 
   display: flex;
   align-items: center;
-  justify-content: space-between;
   background-color: adapter.get-semantic-color(map-get($options, intention), map-get($options, background-color-level));
   color: map-get($options, text-color);
   font-size: adapter.get-font-size(map-get($options, size));
@@ -18,7 +17,6 @@
 
   &.-inline {
     display: inline-flex;
-    justify-content: flex-start;
   }
 
   &.-color-positive {
@@ -33,31 +31,14 @@
     @include -state-style(notice);
   }
 
-  ._group {
-    display: flex;
-    align-items: center;
-    gap: adapter.get-spacing-size(map-get($options, size));
-  }
-
-  ._button {
-    flex-shrink: 0;
-    font-family: inherit;
-    font-size: adapter.get-font-size(map-get($options, size));
-    font-weight: bold;
-    color: map-get($options, button-text-color);
-    border: none;
-    background-color: transparent;
-    cursor: pointer;
+  ._trailing {
+    margin-left: auto;
   }
 }
 
 @mixin -state-style($state) {
   background-color: adapter.get-semantic-color($state, 100);
   color: adapter.get-semantic-color($state, 800);
-
-  ._button {
-    color: inherit;
-  }
 }
 
 @mixin export {

--- a/packages/snackbar/_mixins.scss
+++ b/packages/snackbar/_mixins.scss
@@ -12,7 +12,10 @@
   gap: adapter.get-spacing-size(map-get($options, size));
   border-radius: adapter.get-radius-size(map-get($options, size));
   box-shadow: adapter.get-elevation-box-shadow(1);
-
+  visibility: hidden;
+  opacity: 0;
+  translate: 0 10%;
+  transition: all 0.4s;
   @include -state-style(map-get($options, color));
 
   &.-color-positive {
@@ -30,6 +33,15 @@
   &.-inline {
     display: inline-flex;
   }
+
+  &:active,
+  &.--active {
+    visibility: visible;
+    opacity: 1;
+    translate: 0 0;
+    transition: all 0.4s;
+  }
+
 
   ._trailing {
     margin-left: auto;

--- a/packages/snackbar/_variables.scss
+++ b/packages/snackbar/_variables.scss
@@ -1,0 +1,9 @@
+@use "@pepabo-inhouse/adapter/functions" as adapter;
+
+$default-options: (
+  intention: neutral,
+  background-color-level: 100,
+  text-color: adapter.get-text-color(light, high_emphasis),
+  size: m,
+  button-text-color: adapter.get-implication-color(interactive, 600)
+);

--- a/packages/snackbar/_variables.scss
+++ b/packages/snackbar/_variables.scss
@@ -1,9 +1,6 @@
 @use "@pepabo-inhouse/adapter/functions" as adapter;
 
 $default-options: (
-  intention: neutral,
-  background-color-level: 100,
-  text-color: adapter.get-text-color(light, high_emphasis),
+  color: neutral,
   size: m,
-  button-text-color: adapter.get-implication-color(interactive, 600)
 );

--- a/packages/snackbar/inhouse-snackbar.scss
+++ b/packages/snackbar/inhouse-snackbar.scss
@@ -1,0 +1,2 @@
+@use "./mixins";
+@include mixins.export;

--- a/packages/snackbar/package-lock.json
+++ b/packages/snackbar/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "@pepabo-inhouse/snackbar",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@pepabo-inhouse/snackbar",
+      "version": "0.1.0",
+      "dependencies": {
+        "@pepabo-inhouse/adapter": "^0.43.0",
+        "@pepabo-inhouse/constants": "^0.43.0"
+      },
+      "devDependencies": {
+        "@pepabo-inhouse/flavor": "^0.43.0",
+        "@pepabo-inhouse/tokens": "^0.14.0"
+      }
+    },
+    "node_modules/@pepabo-inhouse/adapter": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@pepabo-inhouse/adapter/-/adapter-0.43.0.tgz",
+      "integrity": "sha512-Sc3KJDdk+uFddCHyp8uypr4EtB8jUmFCx8HrR4rd/qgUPCG/3VtyjMcNAYFEedAo2KJtQWNxtbZnP53vFXujvA==",
+      "dependencies": {
+        "@pepabo-inhouse/constants": "^0.43.0"
+      }
+    },
+    "node_modules/@pepabo-inhouse/constants": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@pepabo-inhouse/constants/-/constants-0.43.0.tgz",
+      "integrity": "sha512-N2okxchoSABADG5Q38mKuZgczEMallrWssXnAosGTePBVYp20C6oO5gvaaSe/TJ2CwBWEG554x5M72I43LsyyA=="
+    },
+    "node_modules/@pepabo-inhouse/flavor": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@pepabo-inhouse/flavor/-/flavor-0.43.0.tgz",
+      "integrity": "sha512-L91jYQ2aMksPoHO4RrRaJFPwk2DGI6K3/pzZYJVXcnC9r/BTmfEki4bkAzusEdA0kCyEA+/RZKlbZwbNFwz0yA==",
+      "dev": true,
+      "dependencies": {
+        "@pepabo-inhouse/tokens": "^0.14.0"
+      }
+    },
+    "node_modules/@pepabo-inhouse/tokens": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@pepabo-inhouse/tokens/-/tokens-0.14.0.tgz",
+      "integrity": "sha512-UNVcZ1L5rjSVfUyNlslRP17uzij8ImlBjmY5rUoZ/eP9D1C6YzT+R/ajq7U6M5znWzVH2HaxLVH5iUL5zi2Z8w==",
+      "dev": true
+    }
+  }
+}

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@pepabo-inhouse/snackbar",
+  "description": "Inhouse Components for the web snackbar component",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pepabo/inhouse-components-web.git",
+    "directory": "packages/snackbar"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pepabo-inhouse/adapter": "^0.43.0"
+  },
+  "devDependencies": {
+    "@pepabo-inhouse/flavor": "^0.43.0",
+    "@pepabo-inhouse/tokens": "^0.14.0"
+  }
+}

--- a/packages/stories-web/package.json
+++ b/packages/stories-web/package.json
@@ -41,6 +41,7 @@
     "@pepabo-inhouse/textfield": "^1.0.0",
     "@pepabo-inhouse/thumbnail": "^1.0.0",
     "@pepabo-inhouse/tokens": "^0.14.0",
+    "@pepabo-inhouse/snackbar": "^0.1.0",
     "@storybook/addon-essentials": "^7.0.6",
     "@storybook/react": "^7.0.6",
     "@storybook/react-webpack5": "^7.0.6",

--- a/packages/stories-web/src/components/Snackbar.tsx
+++ b/packages/stories-web/src/components/Snackbar.tsx
@@ -17,7 +17,7 @@ export const Snackbar: FC<Props> = ({ color = "neutral" }) => {
         <span className="in-icon" data-icon="check" />
         <span>アイテム1を削除しました</span>
         <div className="_trailing">
-          <button className="in-button -size-s">
+          <button className="in-button -size-s -appearance-transparent">
             <div className="_body">もとに戻す</div>
           </button>
         </div>
@@ -25,9 +25,11 @@ export const Snackbar: FC<Props> = ({ color = "neutral" }) => {
       <div className={`in-snackbar -color-${color} -inline`}>
         <span className="in-icon _icon" data-icon="check" />
         <span>アイテム1を削除しました</span>
-        <button className="in-button -size-s">
-          <div className="_body">もとに戻す</div>
-        </button>
+        <div className="_trailing">
+          <button className="in-button -size-s -appearance-transparent">
+            <div className="_body">もとに戻す</div>
+          </button>
+        </div>
       </div>
     </>
   );

--- a/packages/stories-web/src/components/Snackbar.tsx
+++ b/packages/stories-web/src/components/Snackbar.tsx
@@ -1,12 +1,16 @@
 import React, { FC, InputHTMLAttributes } from "react";
+import { SemanticColor } from "./types";
 
 type HTMLProps = InputHTMLAttributes<HTMLInputElement>;
 
 export interface Props extends HTMLProps {
-  color?: string;
+  color?: Extract<
+    SemanticColor,
+    "neutral" | "positive" | "negative" | "notice"
+  >;
 }
 
-export const Snackbar: FC<Props> = ({ color = "" }) => {
+export const Snackbar: FC<Props> = ({ color = "neutral" }) => {
   return (
     <>
       <div className={`in-snackbar -color-${color}`}>

--- a/packages/stories-web/src/components/Snackbar.tsx
+++ b/packages/stories-web/src/components/Snackbar.tsx
@@ -8,22 +8,23 @@ export interface Props extends HTMLProps {
     SemanticColor,
     "neutral" | "positive" | "negative" | "notice"
   >;
+  isActive?: boolean;
+  isInline?: boolean;
 }
 
-export const Snackbar: FC<Props> = ({ color = "neutral" }) => {
+export const Snackbar: FC<Props> = ({
+  color = "neutral",
+  isActive = true,
+  isInline = false,
+}) => {
   return (
     <>
-      <div className={`in-snackbar -color-${color}`}>
+      <div
+        className={`in-snackbar -color-${color} ${isActive ? "--active" : ""} ${
+          isInline ? "-inline" : ""
+        }`}
+      >
         <span className="in-icon" data-icon="check" />
-        <span>アイテム1を削除しました</span>
-        <div className="_trailing">
-          <button className="in-button -size-s -appearance-transparent">
-            <div className="_body">もとに戻す</div>
-          </button>
-        </div>
-      </div>
-      <div className={`in-snackbar -color-${color} -inline`}>
-        <span className="in-icon _icon" data-icon="check" />
         <span>アイテム1を削除しました</span>
         <div className="_trailing">
           <button className="in-button -size-s -appearance-transparent">

--- a/packages/stories-web/src/components/Snackbar.tsx
+++ b/packages/stories-web/src/components/Snackbar.tsx
@@ -14,7 +14,7 @@ export const Snackbar: FC<Props> = ({ color = "neutral" }) => {
   return (
     <>
       <div className={`in-snackbar -color-${color}`}>
-        <span className="in-icon _icon" data-icon="check" />
+        <span className="in-icon" data-icon="check" />
         <span>アイテム1を削除しました</span>
         <div className="_trailing">
           <button className="in-button -size-s">

--- a/packages/stories-web/src/components/Snackbar.tsx
+++ b/packages/stories-web/src/components/Snackbar.tsx
@@ -19,10 +19,13 @@ export const Snackbar: FC<Props> = ({
 }) => {
   return (
     <>
+      {/* note: 表示したときにキーボードでアクションを実行できるよう、focusを当てる */}
       <div
         className={`in-snackbar -color-${color} ${isActive ? "--active" : ""} ${
           isInline ? "-inline" : ""
         }`}
+        aria-live="polite"
+        aria-atomic="true"
       >
         <span className="in-icon" data-icon="check" />
         <span>アイテム1を削除しました</span>

--- a/packages/stories-web/src/components/snackbar/Snackbar.tsx
+++ b/packages/stories-web/src/components/snackbar/Snackbar.tsx
@@ -1,0 +1,34 @@
+import React, { FC, InputHTMLAttributes } from "react";
+
+type HTMLProps = InputHTMLAttributes<HTMLInputElement>;
+
+export interface Props extends HTMLProps {
+  color?: string;
+}
+
+export const Snackbar: FC<Props> = ({ color = "" }) => {
+  return (
+    <>
+      <div className={`in-snackbar -color-${color}`}>
+        <div className="_group">
+          <span className="in-icon _icon" data-icon="check" />
+          <span>アイテム1を削除しました</span>
+        </div>
+        <button className="_button" type="button">
+          もとに戻す
+        </button>
+      </div>
+      <div className={`in-snackbar -color-${color} -inline`}>
+        <div className="_group">
+          <span className="in-icon _icon" data-icon="check" />
+          <span>アイテム1を削除しました</span>
+        </div>
+        <button className="_button" type="button">
+          もとに戻す
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default Snackbar;

--- a/packages/stories-web/src/components/snackbar/Snackbar.tsx
+++ b/packages/stories-web/src/components/snackbar/Snackbar.tsx
@@ -10,21 +10,19 @@ export const Snackbar: FC<Props> = ({ color = "" }) => {
   return (
     <>
       <div className={`in-snackbar -color-${color}`}>
-        <div className="_group">
-          <span className="in-icon _icon" data-icon="check" />
-          <span>アイテム1を削除しました</span>
+        <span className="in-icon _icon" data-icon="check" />
+        <span>アイテム1を削除しました</span>
+        <div className="_trailing">
+          <button className="in-button -size-s">
+            <div className="_body">もとに戻す</div>
+          </button>
         </div>
-        <button className="_button" type="button">
-          もとに戻す
-        </button>
       </div>
       <div className={`in-snackbar -color-${color} -inline`}>
-        <div className="_group">
-          <span className="in-icon _icon" data-icon="check" />
-          <span>アイテム1を削除しました</span>
-        </div>
-        <button className="_button" type="button">
-          もとに戻す
+        <span className="in-icon _icon" data-icon="check" />
+        <span>アイテム1を削除しました</span>
+        <button className="in-button -size-s">
+          <div className="_body">もとに戻す</div>
         </button>
       </div>
     </>

--- a/packages/stories-web/src/snackbar.stories.tsx
+++ b/packages/stories-web/src/snackbar.stories.tsx
@@ -1,6 +1,6 @@
 import type { StoryFn, Meta } from "@storybook/react";
 import React from "react";
-import Snackbar, { Props } from "./components/snackbar/Snackbar";
+import Snackbar, { Props } from "./components/Snackbar";
 
 export default {
   title: "Components/Snackbar",
@@ -9,8 +9,8 @@ export default {
 
 const Template: StoryFn<Props> = (args) => <Snackbar {...args} />;
 
-export const Default = Template.bind({});
-Default.args = {};
+export const Neutral = Template.bind({});
+Neutral.args = {};
 
 export const Positive = Template.bind({});
 Positive.args = { color: "positive" };

--- a/packages/stories-web/src/snackbar.stories.tsx
+++ b/packages/stories-web/src/snackbar.stories.tsx
@@ -1,0 +1,22 @@
+import type { StoryFn, Meta } from "@storybook/react";
+import React from "react";
+import Snackbar, { Props } from "./components/snackbar/Snackbar";
+
+export default {
+  title: "Components/Snackbar",
+  component: Snackbar,
+} as Meta;
+
+const Template: StoryFn<Props> = (args) => <Snackbar {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const Positive = Template.bind({});
+Positive.args = { color: "positive" };
+
+export const Negative = Template.bind({});
+Negative.args = { color: "negative" };
+
+export const Notice = Template.bind({});
+Notice.args = { color: "notice" };

--- a/packages/stories-web/src/snackbar.stories.tsx
+++ b/packages/stories-web/src/snackbar.stories.tsx
@@ -10,13 +10,25 @@ export default {
 const Template: StoryFn<Props> = (args) => <Snackbar {...args} />;
 
 export const Neutral = Template.bind({});
-Neutral.args = {};
+Neutral.args = { color: "neutral", isActive: true };
 
 export const Positive = Template.bind({});
-Positive.args = { color: "positive" };
+Positive.args = { color: "positive", isActive: true };
 
 export const Negative = Template.bind({});
-Negative.args = { color: "negative" };
+Negative.args = { color: "negative", isActive: true };
 
 export const Notice = Template.bind({});
-Notice.args = { color: "notice" };
+Notice.args = { color: "notice", isActive: true };
+
+export const NeutralInline = Template.bind({});
+NeutralInline.args = { color: "neutral", isActive: true, isInline: true };
+
+export const PositiveInline = Template.bind({});
+PositiveInline.args = { color: "positive", isActive: true, isInline: true };
+
+export const NegativeInline = Template.bind({});
+NegativeInline.args = { color: "negative", isActive: true, isInline: true };
+
+export const NoticeInline = Template.bind({});
+NoticeInline.args = { color: "notice", isActive: true, isInline: true };


### PR DESCRIPTION
Snackbarコンポーネントを追加しました。

Notion - Snackbar
https://www.notion.so/pepabo/Snackbar-2bb971dc5877419897beecfd89c9d139

block、inline-blockどちらも選択できるようにしてみました。
（size選択とかはいるのかな…とか少し考えたんですが一旦実装せず）

Default
<img width="850" alt="image" src="https://github.com/pepabo/inhouse-components-web/assets/598763/b0397aae-6022-4e89-96a6-526552d09375">

Positive
<img width="851" alt="image" src="https://github.com/pepabo/inhouse-components-web/assets/598763/4d032e8a-1196-4711-9128-679eb2092956">

Negative
<img width="850" alt="image" src="https://github.com/pepabo/inhouse-components-web/assets/598763/5947af11-5cc0-4f7a-afbf-84499ac1c35a">

Notice
<img width="845" alt="image" src="https://github.com/pepabo/inhouse-components-web/assets/598763/efffecaf-1912-4793-bcce-8ce0ddee87bf">

