### PR TITLE
Snackbarを公開する準備

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [Radio](packages/radio)
 - [Select](packages/select)
 - [Side Navigation](packages/side-navigation)
+- [Snackbar](packages/snackbar)
 - [Table](packages/table)
 - [Textfield](packages/textfield)
 

--- a/packages/components-web/package.json
+++ b/packages/components-web/package.json
@@ -39,7 +39,7 @@
     "@pepabo-inhouse/textfield": "^1.0.0",
     "@pepabo-inhouse/thumbnail": "^1.0.0",
     "@pepabo-inhouse/tokens": "^0.14.0",
-    "@pepabo-inhouse/snackbar": "^0.1.0",
+    "@pepabo-inhouse/snackbar": "^1.0.0",
     "autoprefixer": "10.4.14",
     "cssnano": "5.1.15",
     "postcss": "8.4.23",

--- a/packages/snackbar/package-lock.json
+++ b/packages/snackbar/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "@pepabo-inhouse/snackbar",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pepabo-inhouse/snackbar",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
-        "@pepabo-inhouse/adapter": "^0.43.0",
-        "@pepabo-inhouse/constants": "^0.43.0"
+        "@pepabo-inhouse/adapter": "^0.43.0"
       },
       "devDependencies": {
         "@pepabo-inhouse/flavor": "^0.43.0",

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pepabo-inhouse/snackbar",
   "description": "Inhouse Components for the web snackbar component",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/pepabo/inhouse-components-web.git",

--- a/packages/stories-web/package.json
+++ b/packages/stories-web/package.json
@@ -41,7 +41,7 @@
     "@pepabo-inhouse/textfield": "^1.0.0",
     "@pepabo-inhouse/thumbnail": "^1.0.0",
     "@pepabo-inhouse/tokens": "^0.14.0",
-    "@pepabo-inhouse/snackbar": "^0.1.0",
+    "@pepabo-inhouse/snackbar": "^1.0.0",
     "@storybook/addon-essentials": "^7.0.6",
     "@storybook/react": "^7.0.6",
     "@storybook/react-webpack5": "^7.0.6",


### PR DESCRIPTION
Snackbarを公開するため、READMEの更新、およびSnackbarのバージョンを1.0.0にしました。