### PR TITLE
Tableコンポーネントで背景色とボーダーのパターンを追加します

### DIFF
--- a/packages/stories-web/src/components/Table.tsx
+++ b/packages/stories-web/src/components/Table.tsx
@@ -8,6 +8,7 @@ export interface Props extends HTMLProps {
   density?: Density
   size?: Extract<Size, 's' | 'm' | 'l'>
   hasBackground?: boolean
+  hasGridBorder?: boolean
 }
 
 const Table: FC<Props> = (props: Props) => {
@@ -16,6 +17,7 @@ const Table: FC<Props> = (props: Props) => {
     density,
     size,
     hasBackground,
+    hasGridBorder,
     ...rest
   } = props;
 
@@ -31,6 +33,10 @@ const Table: FC<Props> = (props: Props) => {
 
   if (hasBackground) {
     classes.push(`-has-background`)
+  }
+
+  if (hasGridBorder) {
+    classes.push(`-has-grid-border`)
   }
 
   return (

--- a/packages/stories-web/src/components/Table.tsx
+++ b/packages/stories-web/src/components/Table.tsx
@@ -7,6 +7,7 @@ export interface Props extends HTMLProps {
   children: ReactNode
   density?: Density
   size?: Extract<Size, 's' | 'm' | 'l'>
+  hasBackground?: boolean
 }
 
 const Table: FC<Props> = (props: Props) => {
@@ -14,6 +15,7 @@ const Table: FC<Props> = (props: Props) => {
     children,
     density,
     size,
+    hasBackground,
     ...rest
   } = props;
 
@@ -25,6 +27,10 @@ const Table: FC<Props> = (props: Props) => {
 
   if (typeof size !== 'undefined') {
     classes.push(`-size-${size}`)
+  }
+
+  if (hasBackground) {
+    classes.push(`-has-background`)
   }
 
   return (

--- a/packages/stories-web/src/table.stories.tsx
+++ b/packages/stories-web/src/table.stories.tsx
@@ -31,6 +31,12 @@ Index.args = {
         <td className="-align-right">9,000,000</td>
         <td>スウェーデン語</td>
       </tr>
+      <tr>
+        <td>日本</td>
+        <td>東京</td>
+        <td className="-align-right">120,000,000</td>
+        <td>日本語</td>
+      </tr>
     </tbody>
   ),
   density: 'normal',

--- a/packages/table/_mixins.scss
+++ b/packages/table/_mixins.scss
@@ -62,6 +62,14 @@
   td {
     border-bottom: adapter.get-table-border-size() solid adapter.get-border-color($brightness: light, $name: mid_emphasis);
   }
+
+  @if map.get($option, hasBackground) == true {
+    @include -background-rule;
+  }
+
+  &.-has-background {
+    @include -background-rule;
+  }
 }
 
 @mixin -align() {
@@ -75,5 +83,14 @@
 @mixin export {
   .in-table {
     @include style;
+  }
+}
+
+@mixin -background-rule {
+  tr:nth-child(even) td {
+    background-color: adapter.get-surface-color(light, secondary);
+  }
+  tr:nth-child(odd) td {
+    background-color: adapter.get-surface-color(light, primary);
   }
 }

--- a/packages/table/_mixins.scss
+++ b/packages/table/_mixins.scss
@@ -67,8 +67,16 @@
     @include -background-rule;
   }
 
+  @if map.get($option, hasGirdBorder) == true {
+    @include -grid-border;
+  }
+
   &.-has-background {
     @include -background-rule;
+  }
+
+  &.-has-grid-border {
+    @include -grid-border;
   }
 }
 
@@ -92,5 +100,11 @@
   }
   tr:nth-child(odd) td {
     background-color: adapter.get-surface-color(light, primary);
+  }
+}
+
+@mixin -grid-border {
+  th, td {
+    border: adapter.get-table-border-size() solid adapter.get-border-color($brightness: light, $name: mid_emphasis);
   }
 }

--- a/packages/table/_variables.scss
+++ b/packages/table/_variables.scss
@@ -1,4 +1,5 @@
 $default-option: (
+  has-background: false,
   density: normal,
   size: m,
 );

--- a/packages/table/_variables.scss
+++ b/packages/table/_variables.scss
@@ -1,5 +1,6 @@
 $default-option: (
   has-background: false,
+  has-grid-border: false,
   density: normal,
   size: m,
 );


### PR DESCRIPTION
Tableコンポーネントにおいて、以下の見た目をサポートします。

- 偶数行 / 奇数行の色分け
- 格子状のボーダー

| 偶数行 / 奇数行の色分け | 格子状のボーダー |
| --- | --- |
|  <img width="571" alt="image" src="https://github.com/pepabo/inhouse-components-web/assets/19523490/6b7c2aa9-f09d-49bf-81f9-5b056e28addf"> | <img width="575" alt="image" src="https://github.com/pepabo/inhouse-components-web/assets/19523490/8cd3faec-e72f-4721-9673-e9f7892dd78d"> |
