### PR TITLE
progress-indicatorのborderのsizeの展開をする

### DIFF
--- a/packages/adapter/functions/size/_border.scss
+++ b/packages/adapter/functions/size/_border.scss
@@ -49,8 +49,18 @@ $border-size-tokens: map.get(
   @return map.get($border-size-tokens, focus-ring);
 }
 
-@function get-progress-indicator-border-size() {
-  @return map.get($border-size-tokens, progress-indicator);
+@function get-progress-indicator-border-size($size: m) {
+  $tokens: map.get($border-size-tokens, progress-indicator);
+  $available-sizes: ('s', 'm', 'l');
+
+  @if list.index($available-sizes, $size) == null {
+    @error error-message.any-one-of(
+      $value: $size,
+      $available-values: $available-sizes
+    );
+  }
+
+  @return map.get($tokens, $size);
 }
 
 @function get-radio-border-size() {

--- a/packages/progress-indicator/_mixins.scss
+++ b/packages/progress-indicator/_mixins.scss
@@ -62,13 +62,19 @@
     left: adapter.get-spacing-size($level: xxs);
     display: block;
     box-sizing: border-box;
-    border: adapter.get-progress-indicator-border-size() solid adapter.get-progress-indicator-indicator-surface-color();
+    border-style: solid;
+    border-color: adapter.get-progress-indicator-indicator-surface-color();
     border-radius: 50%;
     transform: rotate(45deg);
     transform-origin: center;
     transition: clip-path 0.1s ease;
     content: "";
     clip-path: polygon(0% 0%, 0% 100%, 100% 100%, 100% 0%, 0% 0%, 50% 50%);
+  }
+  @each $size in 's', 'm', 'l' {
+    &.-size-#{$size} {
+      @include -size-style($size);
+    }
   }
 
   @for $i from 0 to 25 {
@@ -312,6 +318,14 @@
         0% 0%,
         50% 50%
       );
+  }
+}
+
+@mixin -size-style($size) {
+  width: adapter.get-circular-progress-indicator-width();
+  height: adapter.get-circular-progress-indicator-height();
+  &::after {
+    border-width: adapter.get-progress-indicator-border-size($size);
   }
 }
 

--- a/packages/stories-web/src/components/progress-indicator/Circular.tsx
+++ b/packages/stories-web/src/components/progress-indicator/Circular.tsx
@@ -1,18 +1,22 @@
 import React, { FC } from 'react'
+import { Size } from '../types';
 
 export interface Props {
   max: number
   value?: number
+  size?: Extract<Size, 's' | 'm' | 'l'>
 }
 
 const Circular: FC<Props> = (props: Props) => {
   const {
     max,
     value,
+    size = "m",
     ...rest
   } = props
 
   const classes = ['in-circular-progress-indicator']
+  classes.push(`-size-${size}`)
 
   let percentage
 


### PR DESCRIPTION
https://github.com/pepabo/inhouse-tokens/pull/11
がmergeされると、tokenでprogress-indicatorのborderのsizeにs,m,lが用意される。
これをcomponent側で使えるようにする。