### PR TITLE
calloutのスタイルを調整

### DIFF
--- a/packages/callout/_mixins.scss
+++ b/packages/callout/_mixins.scss
@@ -14,10 +14,19 @@
 
   ._leading {
     padding-right: adapter.get-spacing-size(s);
+    line-height: inherit;
+  }
+
+  ._body {
+    display: flex;
+    flex-direction: column;
   }
 
   ._title {
-    margin-top: 0;
+    margin-block: 0;
+  }
+  ._content > *:first-child {
+    margin-block: 0;
   }
 
   @include -state-style(map-get($options, color));
@@ -59,12 +68,8 @@
   font-size: adapter.get-font-size($size);
   line-height: adapter.get-line-height($level: $size, $density: normal);
 
-  ._leading {
-    line-height: adapter.get-line-height($level: $size, $density: normal);
-  }
-
-  ._title {
-    padding-bottom: adapter.get-spacing-size(map-get(variables.$title-margin-map, $size));
+  ._body {
+    gap: adapter.get-spacing-size(map-get(variables.$title-margin-map, $size));
   }
 }
 

--- a/packages/callout/_mixins.scss
+++ b/packages/callout/_mixins.scss
@@ -20,6 +20,7 @@
   ._body {
     display: flex;
     flex-direction: column;
+    margin: 0;
   }
 
   ._title {

--- a/packages/callout/_mixins.scss
+++ b/packages/callout/_mixins.scss
@@ -25,8 +25,13 @@
   ._title {
     margin-block: 0;
   }
+
   ._content > *:first-child {
-    margin-block: 0;
+    margin-block-start: 0;
+  }
+
+  ._content > *:last-child {
+    margin-block-end: 0;
   }
 
   @include -state-style(map-get($options, color));

--- a/packages/stories-web/src/callout.stories.tsx
+++ b/packages/stories-web/src/callout.stories.tsx
@@ -18,12 +18,14 @@ Index.args = {
 export const Multiline = Template.bind({})
 Multiline.args = {
   children: <>
-    <div className="_title">更新に失敗しました</div>
-    以下の入力内容を確認してください。
-    <ul>
-      <li>郵便番号が入力されていません</li>
-      <li>決済方法が選択されていません</li>
-    </ul>
+    <p className="_title">更新に失敗しました</p>
+    <div className="_content">
+      <p>以下の入力内容を確認してください。</p>
+      <ul>
+        <li>郵便番号が入力されていません</li>
+        <li>決済方法が選択されていません</li>
+      </ul>
+    </div>
   </>,
   color: "negative"
 }

--- a/packages/stories-web/src/components/Callout.tsx
+++ b/packages/stories-web/src/components/Callout.tsx
@@ -23,8 +23,8 @@ const Callout: FC<Props> = (props: Props) => {
 
   return (
     <div className={wrapperClasses.join(' ')}>
-      <span className="in-icon _leading"></span>
-      <div className="_content">
+      <span className="_leading in-icon"></span>
+      <div className="_body">
         { children }
       </div>
     </div>


### PR DESCRIPTION
## classをInhouseで標準的に使っている命名に変更

当初は

- leading
- contents

というクラスで作ったのを、他のInhouseパッケージと合わせて

- leading
- body
- trailing（今はないが、leadingにbodyときたら必然的に今後増やすこともあるだろう）

といった文書構造由来の名前にした。

想定するマークアップとして、当初は

```
// single line
<div class="in-callout -color-informative -size-m">
  <span class="in-icon _leading"></span>
  <div class="_content">お支払いが確認できませんでした。サービスの利用が制限される場合があります。</div>
</div>
```

```
// multi line
<div class="in-callout -color-negative -size-m">
  <span class="in-icon _leading"></span>
  <div class="_content">
    <div class="_title">更新に失敗しました</div>
    以下の入力内容を確認してください。
    <ul>
    <li>郵便番号が入力されていません</li>
    <li>決済方法が選択されていません</li>
    </ul>
  </div>
</div>
```

だったのを、よりセマンティックに

```
// single line
<div class="in-callout -color-informative -size-m">
  <span class="in-icon _leading"></span>
  <p class="_body">お支払いが確認できませんでした。サービスの利用が制限される場合があります。</p>
</div>
```

```
// multi line
<div class="in-callout -color-negative -size-m">
  <span class="_leading in-icon"></span>
  <div class="_body">
    <p class="_title">更新に失敗しました</p>
    <div class="_content">
      <p>以下の入力内容を確認してください。</p>
      <ul>
        <li>郵便番号が入力されていません</li>
        <li>決済方法が選択されていません</li>
      </ul>
    </div>
  </div>
</div>
```

といったp要素などでのマークアップを想定した作り方にした。

## レイアウト系プロパティの変更

子要素にmarginを指定して要素間の余白を設定していたのをやめ、レイアウト要素にgapを指定し、要素ごとに担う役割に適したプロパティおよび値に調整した。