### PR TITLE
Adapterのcolor functions読み込みにButtonが含まれていなかったので追加

### DIFF
--- a/packages/adapter/functions/color/_index.scss
+++ b/packages/adapter/functions/color/_index.scss
@@ -6,3 +6,5 @@
 @forward "./semantic";
 @forward "./surface";
 @forward "./text";
+
+// note: ./buttonは追加しません。ボタンのスタイリングはget-button-surfaceを直接利用するのではなくget-button-surface-colorやget-button-text-colorなどを利用してください。


### PR DESCRIPTION
ボタンのスタイリングはget-button-surfaceを直接利用するのではなくget-button-surface-colorやget-button-text-colorなどを利用してほしいがために.buttonを公開していないのでは？という考えに至った。
コメントだけ残しておく。

~~minneでadapterのget-button-colorを呼び出そうとしたらfunctionがないって言われたので調べた。
packages/adapter/functions/color/_index.scss でbuttonの読み込みが漏れているように見えたので追加してみました。~~

~~一応バグ？対応なのでadapterのパッチバージョンを上げたほうがいいのか？と思って2.1.0→2.1.1にあげたのですが問題ないでしょうか〜~~