### PR TITLE
Global built-in functionsは将来的に廃止されるので対応する

### DIFF
--- a/packages/adapter/functions/_helpers.scss
+++ b/packages/adapter/functions/_helpers.scss
@@ -237,7 +237,7 @@ $available-hexadecimal-chars: "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", 
   $background-luminance: -compose-luminance($background) + 0.05;
   $foreground-luminance: -compose-luminance($foreground) + 0.05;
 
-  @return math.div(max($background-luminance, $foreground-luminance), min($background-luminance, $foreground-luminance));
+  @return math.div(math.max($background-luminance, $foreground-luminance), math.min($background-luminance, $foreground-luminance));
 }
 
 // 輝度を計算する

--- a/packages/callout/_mixins.scss
+++ b/packages/callout/_mixins.scss
@@ -35,8 +35,8 @@
     margin-block-end: 0;
   }
 
-  @include -state-style(map-get($options, color));
-  @include -size-style(map-get($options, size));
+  @include -state-style(map.get($options, color));
+  @include -size-style(map.get($options, size));
 
   &.-color-informative {
     @include -state-style(informative);
@@ -66,7 +66,7 @@
   color: adapter.get-semantic-color($state, 800);
 
   ._leading:after {
-    content: map-get(variables.$icon-map, $state);
+    content: map.get(variables.$icon-map, $state);
   }
 }
 
@@ -75,7 +75,7 @@
   line-height: adapter.get-line-height($level: $size, $density: normal);
 
   ._body {
-    gap: adapter.get-spacing-size(map-get(variables.$title-margin-map, $size));
+    gap: adapter.get-spacing-size(map.get(variables.$title-margin-map, $size));
   }
 }
 

--- a/packages/snackbar/_mixins.scss
+++ b/packages/snackbar/_mixins.scss
@@ -7,16 +7,16 @@
 
   display: flex;
   align-items: center;
-  font-size: adapter.get-font-size(map-get($options, size));
-  padding: adapter.get-spacing-size(map-get($options, size));
-  gap: adapter.get-spacing-size(map-get($options, size));
-  border-radius: adapter.get-radius-size(map-get($options, size));
+  font-size: adapter.get-font-size(map.get($options, size));
+  padding: adapter.get-spacing-size(map.get($options, size));
+  gap: adapter.get-spacing-size(map.get($options, size));
+  border-radius: adapter.get-radius-size(map.get($options, size));
   box-shadow: adapter.get-elevation-box-shadow(1);
   visibility: hidden;
   opacity: 0;
   translate: 0 10%;
   transition: all 0.4s;
-  @include -state-style(map-get($options, color));
+  @include -state-style(map.get($options, color));
 
   &.-color-positive {
     @include -state-style(positive);


### PR DESCRIPTION
以下のdepracation warningに対応します。sass-migratorで自動的に修正したものです。

```
Deprecation Warning: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use map.get instead.

More info and automated migrator: https://sass-lang.com/d/import
```