### PR TITLE
Focus Ringのアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4403,9 +4403,9 @@
       "link": true
     },
     "node_modules/@pepabo-inhouse/tokens": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@pepabo-inhouse/tokens/-/tokens-2.0.0.tgz",
-      "integrity": "sha512-qc5RbVGZztBl/ZgrnoWG6a4qjWr0ozoEXiqEK+LnCECQPzVvQ/wWX3VPswGyXyBd8Ci+9mXuMdj5YHdz5sPctA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@pepabo-inhouse/tokens/-/tokens-2.2.0.tgz",
+      "integrity": "sha512-5T5wd6IOajoHO3llgAWJQ8yWV3dqcerk8imvIo0vLP6iF4wGGpVG96doYxbJqpIyaoHyx8RxgzONv3j5fND1jQ=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -26239,7 +26239,7 @@
       },
       "devDependencies": {
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/alert": {
@@ -26265,7 +26265,7 @@
       },
       "devDependencies": {
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/avatar": {
@@ -26278,7 +26278,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/bottom-navigation": {
@@ -26290,7 +26290,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/button": {
@@ -26304,7 +26304,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/callout": {
@@ -26316,7 +26316,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/card": {
@@ -26328,7 +26328,7 @@
       },
       "devDependencies": {
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/cell": {
@@ -26340,7 +26340,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/checkbox": {
@@ -26354,7 +26354,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/components-web": {
@@ -26391,7 +26391,7 @@
         "@pepabo-inhouse/table": "^3.0.0",
         "@pepabo-inhouse/textfield": "^3.0.0",
         "@pepabo-inhouse/thumbnail": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0",
+        "@pepabo-inhouse/tokens": "^2.2.0",
         "autoprefixer": "10.4.14",
         "cssnano": "5.1.15",
         "postcss": "^8.4.38",
@@ -26401,7 +26401,10 @@
     },
     "packages/constants": {
       "name": "@pepabo-inhouse/constants",
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dependencies": {
+        "@pepabo-inhouse/tokens": "^2.2.0"
+      }
     },
     "packages/container": {
       "name": "@pepabo-inhouse/container",
@@ -26412,7 +26415,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/description-list": {
@@ -26425,14 +26428,14 @@
       },
       "devDependencies": {
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/flavor": {
       "name": "@pepabo-inhouse/flavor",
       "version": "3.0.0",
       "dependencies": {
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/grid": {
@@ -26445,7 +26448,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/header": {
@@ -26457,7 +26460,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/icon": {
@@ -26469,7 +26472,7 @@
       "devDependencies": {
         "@gyugyu/webfonts-generator": "^1.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/interactive-list": {
@@ -26485,7 +26488,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/interactive-table": {
@@ -26500,7 +26503,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/list": {
@@ -26513,7 +26516,7 @@
       },
       "devDependencies": {
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/navigation-drawer": {
@@ -26527,7 +26530,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/progress-indicator": {
@@ -26539,7 +26542,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/radio": {
@@ -26553,7 +26556,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/scrim": {
@@ -26565,7 +26568,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/select": {
@@ -26577,7 +26580,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/side-navigation": {
@@ -26589,7 +26592,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/skeleton": {
@@ -26601,7 +26604,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/snackbar": {
@@ -26612,7 +26615,7 @@
       },
       "devDependencies": {
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/stories-web": {
@@ -26653,7 +26656,7 @@
         "@pepabo-inhouse/table": "^3.0.0",
         "@pepabo-inhouse/textfield": "^3.0.0",
         "@pepabo-inhouse/thumbnail": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0",
+        "@pepabo-inhouse/tokens": "^2.2.0",
         "@storybook/addon-essentials": "^7.0.6",
         "@storybook/react": "^7.0.6",
         "@storybook/react-webpack5": "^7.0.6",
@@ -26679,7 +26682,7 @@
       },
       "devDependencies": {
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/textfield": {
@@ -26691,7 +26694,7 @@
       "devDependencies": {
         "@pepabo-inhouse/constants": "^3.0.0",
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     },
     "packages/thumbnail": {
@@ -26703,7 +26706,7 @@
       },
       "devDependencies": {
         "@pepabo-inhouse/flavor": "^3.0.0",
-        "@pepabo-inhouse/tokens": "^2.0.0"
+        "@pepabo-inhouse/tokens": "^2.2.0"
       }
     }
   }

--- a/packages/adapter/_functions.scss
+++ b/packages/adapter/_functions.scss
@@ -4,3 +4,4 @@
 @forward "./functions/size";
 @forward "./functions/opacity";
 @forward "./functions/typography";
+@forward "./functions/outline";

--- a/packages/adapter/functions/color/_border.scss
+++ b/packages/adapter/functions/color/_border.scss
@@ -123,6 +123,7 @@ $border-color-tokens: map.get(
   }
 }
 
+/// @deprecated この関数は非推奨です
 @function get-focus-ring-color($color: neutral) {
   $available-colors: list.join(
     helpers.get-semantic-intentions(),
@@ -146,6 +147,37 @@ $border-color-tokens: map.get(
     @return implication-color.get-implication-color(
       $name: $color,
       $level: 500
+    );
+  }
+}
+
+@function get-focus-ring-outline-color($brightness: light,) {
+  $focus-ring-color-tokens: map.get(
+    map.get(tokens.$tokens, color),
+    focus-ring
+  );
+
+  $available-brightnesses: helpers.get-brightnesses();
+
+  @if list.index($available-brightnesses, $brightness) == null {
+    @error error-message.any-one-of(
+      $value: $brightness,
+      $available-values: $available-brightnesses
+    );
+  }
+
+  @if map.get(
+    map.get($focus-ring-color-tokens, base),
+    $brightness
+  ) == null {
+    @return semantic-color.get-semantic-color(
+      $intention: interactive,
+      $level: 500
+    );
+  } @else {
+    @return map.get(
+      map.get($focus-ring-color-tokens, base),
+      $brightness
     );
   }
 }

--- a/packages/adapter/functions/color/_border.test.scss
+++ b/packages/adapter/functions/color/_border.test.scss
@@ -40,6 +40,13 @@
   );
 }
 
+@function test-get-focus-ring-outline-color() {
+  @return assert.equals(
+    functions.get-focus-ring-outline-color($brightness: light),
+    #3e93de
+  );
+}
+
 @function test-get-interactive-list-border-color() {
   @return assert.equals(
     functions.get-interactive-list-border-color(),

--- a/packages/adapter/functions/opacity/_border.scss
+++ b/packages/adapter/functions/opacity/_border.scss
@@ -8,6 +8,7 @@ $border-opacity-tokens: map.get(
   border
 );
 
+/// @deprecated この関数は非推奨です
 @function get-focus-ring-opacity() {
   @return map.get($border-opacity-tokens, focus-ring);
 }

--- a/packages/adapter/functions/outline/_focus-ring.scss
+++ b/packages/adapter/functions/outline/_focus-ring.scss
@@ -1,0 +1,17 @@
+@use "sass:list";
+@use "../color/border" as border-color;
+@use "../opacity/border" as border-opacity;
+@use "../size/border" as border-size;
+@use "../helpers";
+
+@function get-focus-ring-outline($brightness: light) {
+  $width: border-size.get-focus-ring-size();
+  $opacity: border-opacity.get-focus-ring-opacity();
+  $color: border-color.get-focus-ring-outline-color($brightness: $brightness);
+
+  @return #{$width} solid rgba($color, $opacity);
+}
+
+@function get-focus-ring-outline-offset() {
+  @return 0.125rem;
+}

--- a/packages/adapter/functions/outline/_focus-ring.scss
+++ b/packages/adapter/functions/outline/_focus-ring.scss
@@ -6,10 +6,9 @@
 
 @function get-focus-ring-outline($brightness: light) {
   $width: border-size.get-focus-ring-size();
-  $opacity: border-opacity.get-focus-ring-opacity();
   $color: border-color.get-focus-ring-outline-color($brightness: $brightness);
 
-  @return #{$width} solid rgba($color, $opacity);
+  @return #{$width} solid $color;
 }
 
 @function get-focus-ring-outline-offset() {

--- a/packages/adapter/functions/outline/_focus-ring.test.scss
+++ b/packages/adapter/functions/outline/_focus-ring.test.scss
@@ -1,0 +1,16 @@
+@use "./focus-ring" as functions;
+@use "@gyugyu/assert-sass" as assert;
+
+@function test-get-focus-ring-outline() {
+  @return assert.equals(
+    "#{functions.get-focus-ring-outline()}",
+    "0.25rem solid rgba(62, 147, 222, 0.15)"
+  );
+}
+
+@function test-get-focus-ring-outline-offset() {
+  @return assert.equals(
+    functions.get-focus-ring-outline-offset(),
+    0.125rem
+  );
+}

--- a/packages/adapter/functions/outline/_focus-ring.test.scss
+++ b/packages/adapter/functions/outline/_focus-ring.test.scss
@@ -4,7 +4,7 @@
 @function test-get-focus-ring-outline() {
   @return assert.equals(
     "#{functions.get-focus-ring-outline()}",
-    "0.25rem solid rgba(62, 147, 222, 0.15)"
+    "0.25rem solid #3e93de"
   );
 }
 

--- a/packages/adapter/functions/outline/_index.scss
+++ b/packages/adapter/functions/outline/_index.scss
@@ -1,0 +1,1 @@
+@forward "./focus-ring";

--- a/packages/adapter/functions/shadow/_focus-ring.scss
+++ b/packages/adapter/functions/shadow/_focus-ring.scss
@@ -4,6 +4,7 @@
 @use "../size/border" as border-size;
 @use "../helpers";
 
+/// @deprecated この関数は非推奨です。代わりに package/adapter/functions/outline/_focus-ring.scss を参照してください。
 @function get-focus-ring-box-shadow($color: neutral) {
   $width: border-size.get-focus-ring-size();
   $opacity: border-opacity.get-focus-ring-opacity();

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/app-bar/package.json
+++ b/packages/app-bar/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/bottom-navigation/package.json
+++ b/packages/bottom-navigation/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/button/_functions.scss
+++ b/packages/button/_functions.scss
@@ -65,30 +65,37 @@
   $elevation-shadow: adapter.get-elevation-box-shadow($level: 1);
   $scrim-highlight: adapter.get-solid-button-highlight-box-shadow();
   $scrim-shadow: adapter.get-solid-button-shadow-box-shadow();
-  $focus-ring: adapter.get-focus-ring-box-shadow($color: $color);
 
   @if $appearance == flat or $appearance == outlined {
-    @if $state == focused {
-      @return $elevation-shadow, $focus-ring;
-    } @else if $state == disabled {
+    @if $state == disabled {
       @return none;
     } @else {
       @return $elevation-shadow;
     }
   } @else if $appearance == solid {
-    @if $state == focused {
-      @return $elevation-shadow, $scrim-highlight, $scrim-shadow, $focus-ring;
-    } @else if $state == disabled {
+    @if $state == disabled {
       @return $scrim-highlight, $scrim-shadow;
     } @else {
       @return $elevation-shadow, $scrim-highlight, $scrim-shadow;
     }
   } @else {
-    @if $state == focused {
-      @return $focus-ring;
-    } @else {
-      @return none;
-    }
+    @return none;
+  }
+}
+
+@function get-outline($state: enabled) {
+  $available-states: adapter.get-states();
+
+  @if list.index($available-states, $state) == null {
+    @error "$stateには #{$available-states} のいずれかのみ指定できます";
+  }
+
+  $focus-ring: adapter.get-focus-ring-outline();
+
+  @if $state == focused {
+    @return $focus-ring;
+  } @else {
+    @return none;
   }
 }
 

--- a/packages/button/_functions.test.scss
+++ b/packages/button/_functions.test.scss
@@ -31,8 +31,16 @@
   );
 }
 
+@function test-get-outline() {
+  @return assert.equals(
+    "#{functions.get-outline($state: focused)}",
+    "0.25rem solid #3e93de"
+  );
+}
+
 @function test-get-only-leading-width() {
   $actual: functions.get-only-leading-width($size: m);
 
   @return assert.equals("#{$actual}", "calc(2.5rem - 0.125rem)");
 }
+

--- a/packages/button/_mixins.scss
+++ b/packages/button/_mixins.scss
@@ -320,6 +320,8 @@
       $color: $color,
       $state: $state
     );
+  outline: functions.get-outline($state: $state);
+  outline-offset: adapter.get-focus-ring-outline-offset();
 }
 
 @mixin -appearance-state-ruleset($appearance, $brightness, $color) {

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/callout/package.json
+++ b/packages/callout/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/cell/package.json
+++ b/packages/cell/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/checkbox/_functions.scss
+++ b/packages/checkbox/_functions.scss
@@ -48,22 +48,29 @@
     }
   }
 
-  $focus-ring: -get-focus-ring($states: $states);
   $border-overlay: -get-border-overlay($states: $states);
   $border: -get-border($states: $states);
 
-  @if list.index($states, focused) != null {
-    @if list.index($states, selected) != null or list.index($states, mixed) != null {
-      @return $focus-ring, $border;
-    } @else {
-      @return $focus-ring, $border-overlay, $border;
-    }
+  @if list.index($states, selected) != null or list.index($states, mixed) != null {
+    @return $border;
   } @else {
-    @if list.index($states, selected) != null or list.index($states, mixed) != null {
-      @return $border;
-    } @else {
-      @return $border-overlay, $border;
+    @return $border-overlay, $border;
+  }
+}
+
+@function get-outline($states: (enabled), $brightness: light) {
+  $available-states: adapter.get-states();
+
+  @each $state in $states {
+    @if list.index($available-states, $state) == null {
+      @error "$statesには #{$available-states} を組み合わせた配列のみ指定できます";
     }
+  }
+
+  @if list.index($states, focused) != null {
+    @return adapter.get-focus-ring-outline($brightness: $brightness);
+  } @else {
+    @return none;
   }
 }
 
@@ -99,6 +106,7 @@
   }
 }
 
+/// @deprecated この関数は非推奨です
 @function -get-focus-ring($states: (enabled)) {
   @if list.index($states, selected) != null or list.index($states, mixed) != null {
     @return adapter.get-focus-ring-box-shadow($color: informative);

--- a/packages/checkbox/_functions.test.scss
+++ b/packages/checkbox/_functions.test.scss
@@ -22,6 +22,13 @@
   );
 }
 
+@function test-get-outline() {
+  @return assert.equals(
+    "#{functions.get-outline($states: (focused))}",
+    "0.25rem solid #3e93de"
+  );
+}
+
 @function test-get-foreground-content() {
   @return assert.equals(
     functions.get-foreground-content($states: (enabled)),

--- a/packages/checkbox/_mixins.scss
+++ b/packages/checkbox/_mixins.scss
@@ -91,6 +91,7 @@
   border: none;
   outline: none;
   appearance: unset;
+  border-radius: adapter.get-radius-size($level: m);
 }
 
 @mixin -child-element-proto() {
@@ -114,6 +115,8 @@
 
   cursor: functions.get-cursor($states: $states);
   opacity: functions.get-opacity($states: $states);
+
+  @include -outline-style($states: $states);
 
   &::before {
     @include -background-style($states: $states);
@@ -142,4 +145,9 @@
   opacity: functions.get-foreground-opacity($states: $states);
   content: functions.get-foreground-content($states: $states);
   pointer-events: none;
+}
+
+@mixin -outline-style($states: (enabled)) {
+  outline: functions.get-outline($states: $states);
+  outline-offset: adapter.get-focus-ring-outline-offset();
 }

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/components-web/package.json
+++ b/packages/components-web/package.json
@@ -41,7 +41,7 @@
     "@pepabo-inhouse/table": "^3.0.0",
     "@pepabo-inhouse/textfield": "^3.0.0",
     "@pepabo-inhouse/thumbnail": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0",
+    "@pepabo-inhouse/tokens": "^2.2.0",
     "autoprefixer": "10.4.14",
     "cssnano": "5.1.15",
     "postcss": "^8.4.38",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -9,5 +9,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/description-list/package.json
+++ b/packages/description-list/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/flavor/package.json
+++ b/packages/flavor/package.json
@@ -11,6 +11,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/grid/_functions.test.scss
+++ b/packages/grid/_functions.test.scss
@@ -2,44 +2,9 @@
 @use "./functions";
 @use "@gyugyu/assert-sass" as assert;
 
-@function test-get-direction() {
-  @return assert.equals(
-    functions.get-direction(variables.$default-option),
-    ltr
-  );
-}
-
-@function test-compose-row-top-gap() {
-  @return assert.equals(
-    functions.compose-row-top-gap(xxs),
-    -1rem
-  );
-}
-
-@function test-compose-row-horizontal-gap() {
-  @return assert.equals(
-    functions.compose-row-horizontal-gap(xxs),
-    -0.5rem
-  );
-}
-
-@function test-compose-col-top-gap() {
-  @return assert.equals(
-    functions.compose-col-top-gap(xxs),
-    1rem
-  );
-}
-
 @function test-compose-col-horizontal-gap() {
   @return assert.equals(
     functions.compose-col-horizontal-gap(xxs),
-    0.5rem
-  );
-}
-
-@function test-get-col-width() {
-  @return assert.equals(
-    functions.get-col-width(6),
-    50%
+    1rem
   );
 }

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@gyugyu/webfonts-generator": "^1.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   },
   "scripts": {
     "prepublishOnly": "npm run build",

--- a/packages/interactive-list/package.json
+++ b/packages/interactive-list/package.json
@@ -20,6 +20,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/interactive-table/package.json
+++ b/packages/interactive-table/package.json
@@ -19,6 +19,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/navigation-drawer/package.json
+++ b/packages/navigation-drawer/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/progress-indicator/package.json
+++ b/packages/progress-indicator/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/radio/_functions.scss
+++ b/packages/radio/_functions.scss
@@ -39,6 +39,22 @@
   @return $child-element-size * 0.5 * -1;
 }
 
+@function get-outline($states: (enabled)) {
+  $available-states: adapter.get-states();
+
+  @each $state in $states {
+    @if list.index($available-states, $state) == null {
+      @error "$statesには #{$available-states} を組み合わせた配列のみ指定できます";
+    }
+  }
+
+  @if list.index($states, focused) != null {
+    @return adapter.get-focus-ring-outline();
+  } @else {
+    @return none;
+  }
+}
+
 @function get-background-box-shadow($states: (enabled)) {
   $available-states: adapter.get-states();
 
@@ -48,25 +64,17 @@
     }
   }
 
-  $focus-ring: -get-focus-ring($states: $states);
   $border-overlay: -get-border-overlay($states: $states);
   $border: -get-border($states: $states);
 
-  @if list.index($states, focused) != null {
-    @if list.index($states, selected) != null {
-      @return $focus-ring, $border;
-    } @else {
-      @return $focus-ring, $border-overlay, $border;
-    }
+  @if list.index($states, selected) != null {
+    @return $border;
   } @else {
-    @if list.index($states, selected) != null {
-      @return $border;
-    } @else {
-      @return $border-overlay, $border;
-    }
+    @return $border-overlay, $border;
   }
 }
 
+/// @deprecated この関数は非推奨です
 @function -get-focus-ring($states: (enabled)) {
   @if list.index($states, selected) != null {
     @return adapter.get-focus-ring-box-shadow($color: informative);

--- a/packages/radio/_functions.test.scss
+++ b/packages/radio/_functions.test.scss
@@ -21,3 +21,10 @@
     -0.625rem
   );
 }
+
+@function test-get-outline() {
+  @return assert.equals(
+    "#{functions.get-outline($states: (focused))}",
+    "0.25rem solid #3e93de"
+  );
+}

--- a/packages/radio/_mixins.scss
+++ b/packages/radio/_mixins.scss
@@ -92,6 +92,9 @@
 
   cursor: functions.get-cursor($states: $states);
   opacity: functions.get-opacity($states: $states);
+  outline: functions.get-outline($states: $states);
+  outline-offset: adapter.get-focus-ring-outline-offset();
+  border-radius: 50%;
 
   &::before {
     @include -background-style($states: $states);

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/scrim/package.json
+++ b/packages/scrim/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/select/_mixins.scss
+++ b/packages/select/_mixins.scss
@@ -181,17 +181,8 @@
       }
 
       @include -focus-rule {
-        box-shadow: inset 0 0 0 #{adapter.get-border-size($level: m)} #{adapter.get-field-border-color(
-              $color: $intention,
-              $state: focused
-            )},
-          #{adapter.get-focus-ring-box-shadow(
-              $color:
-                adapter.get-field-border-color(
-                  $color: $intention,
-                  $state: focused
-                )
-            )};
+        outline: adapter.get-focus-ring-outline();
+        outline-offset: adapter.get-focus-ring-outline-offset();
       }
     }
   } @else if $appearance == filled {
@@ -205,7 +196,8 @@
       }
 
       @include -focus-rule {
-        box-shadow: inset 0 #{0 - adapter.get-border-size($level: m)} 0 0 #{adapter.get-field-border-color($color: $intention, $state: focused)}, #{adapter.get-focus-ring-box-shadow($color: adapter.get-field-border-color($color: $intention, $state: focused))};
+        outline: adapter.get-focus-ring-outline();
+        outline-offset: adapter.get-focus-ring-outline-offset();
       }
     }
   }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/side-navigation/package.json
+++ b/packages/side-navigation/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/stories-web/package.json
+++ b/packages/stories-web/package.json
@@ -43,7 +43,7 @@
     "@pepabo-inhouse/table": "^3.0.0",
     "@pepabo-inhouse/textfield": "^3.0.0",
     "@pepabo-inhouse/thumbnail": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0",
+    "@pepabo-inhouse/tokens": "^2.2.0",
     "@storybook/addon-essentials": "^7.0.6",
     "@storybook/react": "^7.0.6",
     "@storybook/react-webpack5": "^7.0.6",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/textfield/_mixins.scss
+++ b/packages/textfield/_mixins.scss
@@ -214,17 +214,8 @@
       }
 
       @include -focus-rule {
-        box-shadow: inset 0 0 0 #{adapter.get-border-size($level: m)} #{adapter.get-field-border-color(
-              $color: $intention,
-              $state: focused
-            )},
-          #{adapter.get-focus-ring-box-shadow(
-              $color:
-                adapter.get-field-border-color(
-                  $color: $intention,
-                  $state: focused
-                )
-            )};
+        outline: adapter.get-focus-ring-outline();
+        outline-offset: adapter.get-focus-ring-outline-offset();
       }
     }
   } @else if $appearance == filled {
@@ -244,17 +235,8 @@
       }
 
       @include -focus-rule {
-        box-shadow: inset 0 #{0 - adapter.get-border-size($level: m)} 0 0 #{adapter.get-field-border-color(
-              $color: $intention,
-              $state: focused
-            )},
-          #{adapter.get-focus-ring-box-shadow(
-              $color:
-                adapter.get-field-border-color(
-                  $color: $intention,
-                  $state: focused
-                )
-            )};
+        outline: adapter.get-focus-ring-outline();
+        outline-offset: adapter.get-focus-ring-outline-offset();
       }
     }
   }

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@pepabo-inhouse/constants": "^3.0.0",
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }

--- a/packages/thumbnail/package.json
+++ b/packages/thumbnail/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "@pepabo-inhouse/flavor": "^3.0.0",
-    "@pepabo-inhouse/tokens": "^2.0.0"
+    "@pepabo-inhouse/tokens": "^2.2.0"
   }
 }


### PR DESCRIPTION
# 概要
既存のfocus ringをWCAGの基準と照らし合わせたときに、視認性などの観点から問題があることがわかった。
今回の改修でよりfocusされていることが伝わるような見た目にする。

## やったこと
- Inhouse Tokenによりサービスごとのfocus ringカラーを指定できるようにした
  - https://github.com/pepabo/inhouse-tokens/pull/13
- focus ringをshadowではなくoutlineで表現する
  - outline offsetも利用しよりコントラストを強める

## 目指す基準
### 1.4.11：非テキストのコントラスト【AA】

- 非テキストの視覚的な情報は、隣接した色とのコントラスト比3.1以上を確保
- フォーカスに限らない内容

### 2.4.7：フォーカスの可視化【AA】

- フォーカスを認識できるようにしましょう、という内容

### 2.4.13：フォーカスの外観【AAA】

- 1.4.11と2.4.7を前提としたフォーカス時の外観の話
- フォーカス時の表現方法に厳密な指定はない
    - Outline、背景色の変更、シャドウなどもOK（良し悪しの判断あり）
    - ただ、Outlineとoutline-offsetでやるのが一番簡単なので推奨されている
- 良し悪しの判断基準
    - 最小面積要件
        - フォーカスされていないコンポーネントまたはサブコンポーネントの2 [CSSピクセル](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance#dfn-css-pixel)厚の[周囲](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance#dfn-perimeter)の領域と少なくとも同じ大きさである
    - 色の変更
        - フォーカス状態の色と非フォーカス状態の色とでコントラスト比3.1以上の差をつけよう（1.4.11とは別の話）
    - シャドウ
        - グラデーションがある場合、コントラスト3.1以下を無視し、3.1以上の領域が最小面積要件を満たしているか


## Focus Ring表示イメージ

| components | before | after（colorはTokenで設定される） |
| -- | -- | -- |
| button | <img width="117" alt="image" src="https://github.com/user-attachments/assets/fd4696d3-dadb-4afe-8a39-49b6ed74f0bd"> | <img width="106" alt="image" src="https://github.com/user-attachments/assets/51b376c9-580e-419f-8358-fcb76d83ecaf"> |
| check box | <img width="46" alt="image" src="https://github.com/user-attachments/assets/a32efd2a-fb30-49df-baed-1dfb1814522f"> | <img width="65" alt="image" src="https://github.com/user-attachments/assets/2eed10ca-7f41-4228-8762-0eb2d9699643"> |
| radio | <img width="50" alt="image" src="https://github.com/user-attachments/assets/a445e135-022c-4614-b564-6f055fa42d57"> | <img width="52" alt="image" src="https://github.com/user-attachments/assets/13e117b6-e115-454a-9bd3-783a5fba7acb"> |
| select | <img width="160" alt="image" src="https://github.com/user-attachments/assets/fa0fe3b1-5a91-487c-a0ca-00306b142cfe"> | <img width="148" alt="image" src="https://github.com/user-attachments/assets/2f859a9b-d999-429b-be8e-5a0f6ca4dd19"> |
| text field | <img width="293" alt="image" src="https://github.com/user-attachments/assets/53adfb0e-070d-4b1b-bd2e-38e8f254d3a8"> | <img width="281" alt="image" src="https://github.com/user-attachments/assets/88ef9a97-5de8-414e-98a4-0d790fb3a405"> |
