### PR TITLE
focusの擬似クラスをfocus-visibleに変更

### DIFF
--- a/packages/bottom-navigation/_mixins.scss
+++ b/packages/bottom-navigation/_mixins.scss
@@ -125,7 +125,7 @@
       );
   }
 
-  &:focus,
+  &:focus-visible,
   &.--focused {
     background-color:
       functions.get-action-background-color(

--- a/packages/button/_mixins.scss
+++ b/packages/button/_mixins.scss
@@ -335,7 +335,7 @@
     );
   }
 
-  &:focus,
+  &:focus-visible,
   &.--focused {
     @include -appearance-style(
       $appearance: $appearance,

--- a/packages/checkbox/_mixins.scss
+++ b/packages/checkbox/_mixins.scss
@@ -15,7 +15,7 @@
     @include -ruleset($states: (hover));
   }
 
-  &:focus,
+  &:focus-visible,
   &.--focused {
     @include -ruleset($states: (focused));
   }
@@ -34,9 +34,9 @@
     @include -ruleset($states: (disabled));
   }
 
-  &:checked:focus,
+  &:checked:focus-visible,
   &:checked.--focused,
-  &.--selected:focus,
+  &.--selected:focus-visible,
   &.--selected.--focused {
     @include -ruleset($states: (selected, focused));
   }

--- a/packages/interactive-list/_mixins.scss
+++ b/packages/interactive-list/_mixins.scss
@@ -43,7 +43,7 @@
     & > a,
     & > button,
     & > label {
-      &:focus,
+      &:focus-visible,
       &.--focused {
         background-color:
           adapter-functions.get-background-overlay-color(
@@ -160,7 +160,7 @@
           $state: selected
         );
 
-      &:focus,
+      &:focus-visible,
       &:hover {
         background-color:
           adapter-functions.get-background-overlay-color(
@@ -178,7 +178,7 @@
           $state: activated
         );
 
-      &:focus,
+      &:focus-visible,
       &:hover {
         background-color:
           adapter-functions.get-background-overlay-color(

--- a/packages/radio/_mixins.scss
+++ b/packages/radio/_mixins.scss
@@ -15,7 +15,7 @@
     @include -ruleset($states: (hover));
   }
 
-  &:focus,
+  &:focus-visible,
   &.--focused {
     @include -ruleset($states: (focused));
   }
@@ -30,9 +30,9 @@
     @include -ruleset($states: (disabled));
   }
 
-  &:checked:focus,
+  &:checked:focus-visible,
   &:checked.--focused,
-  &.--selected:focus,
+  &.--selected:focus-visible,
   &.--selected.--focused {
     @include -ruleset($states: (selected, focused));
   }

--- a/packages/select/_mixins.scss
+++ b/packages/select/_mixins.scss
@@ -109,7 +109,7 @@
 }
 
 @mixin -focus-rule {
-  &:focus,
+  &:focus-visible,
   &.--focused {
     @content;
   }

--- a/packages/textfield/_mixins.scss
+++ b/packages/textfield/_mixins.scss
@@ -122,7 +122,7 @@
 }
 
 @mixin -focus-rule {
-  &:focus,
+  &:focus-visible,
   &.--focused {
     @content;
   }


### PR DESCRIPTION
focus擬似クラスで指定したfocus-ringなど視覚的なフォーカスステートを[focus-visible擬似クラス](https://developer.mozilla.org/ja/docs/Web/CSS/:focus-visible)に変更して、ブラウザが視覚的にフォーカスステートを必要と判断した場合にfocus-ringなどが適用される状態にします。