### PR TITLE
activeステート追加

### DIFF
--- a/packages/button/_mixins.scss
+++ b/packages/button/_mixins.scss
@@ -335,6 +335,16 @@
     );
   }
 
+  &:active,
+  &.--active {
+    @include -appearance-style(
+      $appearance: $appearance,
+      $brightness: $brightness,
+      $color: $color,
+      $state: active
+    );
+  }
+
   &:focus-visible,
   &.--focused {
     @include -appearance-style(

--- a/packages/constants/_variables.scss
+++ b/packages/constants/_variables.scss
@@ -7,6 +7,7 @@ $priorities: (
 $states: (
   enabled,
   hover,
+  active,
   focused,
   selected,
   activated,

--- a/packages/stories-web/src/components/button/Button.tsx
+++ b/packages/stories-web/src/components/button/Button.tsx
@@ -12,7 +12,7 @@ export interface Props extends HTMLProps {
   leading?: ReactNode
   shape?: Shape
   size?: Extract<Size, 'xs' | 's' | 'm' | 'l' | 'xl'>
-  state?: Extract<State, 'enabled' | 'hover' | 'focused' | 'disabled'>
+  state?: Extract<State, 'enabled' | 'hover' | 'active' | 'focused' | 'disabled'>
   trailing?: ReactNode
   width?: Width
 }

--- a/packages/stories-web/src/components/demo/ButtonDemo.tsx
+++ b/packages/stories-web/src/components/demo/ButtonDemo.tsx
@@ -18,6 +18,11 @@ const ButtonDemo: FC<Props> = (props: Props) => (
     <Button
       {...props}
       body='Button'
+      state='active'
+    />
+    <Button
+      {...props}
+      body='Button'
       state='focused'
     />
     <Button


### PR DESCRIPTION
buttonの `:active` スタイルが無くGUIとしてのフィードバックが得られない状態だったので、追加しました。
https://github.com/pepabo/inhouse-tokens/pull/17 で追加したdesign tokenを使っています。

![スクリーンショット 2025-01-17 9 53 14](https://github.com/user-attachments/assets/b9b79d9f-c56a-4bef-8ebc-8c930ee8247f)

左からdefault, hover, active, focus-visible, disabled それぞれのbuttonが並んだ、Storybookのキャプチャ画像です。押したらhoverより暗くなって凹んだ感じに視覚的なフィードバックを返しています。