### PR TITLE
inhouse/tableのalign optionは物理ではなく論理プロパティ的なclass名で使う

### DIFF
--- a/packages/stories-web/src/table.stories.tsx
+++ b/packages/stories-web/src/table.stories.tsx
@@ -16,25 +16,25 @@ Index.args = {
       <tr>
         <th>国</th>
         <th>首都</th>
-        <th className="-align-right">人口</th>
+        <th className="-align-end">人口</th>
         <th>言語</th>
       </tr>
       <tr>
         <td>アメリカ合衆国</td>
         <td>ワシントンD.C.</td>
-        <td className="-align-right">390,000,000</td>
+        <td className="-align-end">390,000,000</td>
         <td>英語</td>
       </tr>
       <tr>
         <td>スウェーデン</td>
         <td>ストックホルム</td>
-        <td className="-align-right">9,000,000</td>
+        <td className="-align-end">9,000,000</td>
         <td>スウェーデン語</td>
       </tr>
       <tr>
         <td>日本</td>
         <td>東京</td>
-        <td className="-align-right">120,000,000</td>
+        <td className="-align-end">120,000,000</td>
         <td>日本語</td>
       </tr>
     </tbody>


### PR DESCRIPTION
[tableのstorybook](https://pepabo.github.io/inhouse-components-web/?path=/story/components-table--index) を見ると、人口の列は `-align-right` なるclassが指定されているのですが右揃えにはなっていません。
tableの実装を見ると、[constants](https://github.com/pepabo/inhouse-components-web/blob/ca64012d32a2efb1025511bdc16e5ed7c6f3860d/packages/constants/_variables.scss#L131-L134)の `table-align-values` で定義された `start` または `end` を使うようになっているので、Storybookを `-align-end` に変更しました。