### PR TITLE
Calloutコンポーネントに閉じるボタンを追加します

### DIFF
--- a/packages/callout/_mixins.scss
+++ b/packages/callout/_mixins.scss
@@ -12,6 +12,11 @@
   box-shadow: adapter.get-elevation-box-shadow(1);
   $options: map.merge(variables.$default-options, $options);
 
+  visibility: hidden;
+  opacity: 0%;
+  transition: all 0.4s;
+  translate: 0 10%;
+
   ._leading {
     padding-right: adapter.get-spacing-size(s);
     line-height: inherit;
@@ -33,6 +38,18 @@
 
   ._content > *:last-child {
     margin-block-end: 0;
+  }
+
+  &:active,
+  &.--active {
+    visibility: visible;
+    opacity: 100%;
+    translate: 0 0;
+    transition: all 0.4s;
+  }
+
+  ._trailing {
+    margin-left: auto;
   }
 
   @include -state-style(map.get($options, color));

--- a/packages/callout/_mixins.scss
+++ b/packages/callout/_mixins.scss
@@ -40,14 +40,6 @@
     margin-block-end: 0;
   }
 
-  &:active,
-  &.--active {
-    visibility: visible;
-    opacity: 100%;
-    translate: 0 0;
-    transition: all 0.4s;
-  }
-
   ._trailing {
     margin-left: auto;
   }

--- a/packages/callout/_mixins.scss
+++ b/packages/callout/_mixins.scss
@@ -12,11 +12,6 @@
   box-shadow: adapter.get-elevation-box-shadow(1);
   $options: map.merge(variables.$default-options, $options);
 
-  visibility: hidden;
-  opacity: 0%;
-  transition: all 0.4s;
-  translate: 0 10%;
-
   ._leading {
     padding-right: adapter.get-spacing-size(s);
     line-height: inherit;

--- a/packages/stories-web/src/components/Callout.tsx
+++ b/packages/stories-web/src/components/Callout.tsx
@@ -8,6 +8,8 @@ export interface Props {
     "informative" | "positive" | "negative" | "notice"
   >;
   size?: Extract<Size, 's' | 'm' | 'l'>;
+  isActive?: boolean;
+  hasCloseButton?: boolean;
 }
 
 const Callout: FC<Props> = (props: Props) => {
@@ -15,18 +17,34 @@ const Callout: FC<Props> = (props: Props) => {
   const {
     color = "informative",
     size = "m",
+    isActive = true,
+    hasCloseButton = false,
     children
   } = props
 
   wrapperClasses.push(`-color-${color}`)
   wrapperClasses.push(`-size-${size}`)
 
+  if (hasCloseButton === false || isActive === true) {
+    wrapperClasses.push(`--active`)
+  }
+
   return (
-    <div className={wrapperClasses.join(' ')}>
+    <div
+      className={wrapperClasses.join(' ')}
+      aria-live="polite"
+    >
       <span className="_leading in-icon"></span>
       <div className="_body">
         { children }
       </div>
+      { hasCloseButton && (
+        <div className="_trailing">
+          <button className="in-button -size-s -appearance-transparent">
+            <div className="_body">閉じる</div>
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/stories-web/src/components/Callout.tsx
+++ b/packages/stories-web/src/components/Callout.tsx
@@ -8,8 +8,7 @@ export interface Props {
     "informative" | "positive" | "negative" | "notice"
   >;
   size?: Extract<Size, 's' | 'm' | 'l'>;
-  isActive?: boolean;
-  hasCloseButton?: boolean;
+  hasButton?: boolean;
 }
 
 const Callout: FC<Props> = (props: Props) => {
@@ -17,17 +16,12 @@ const Callout: FC<Props> = (props: Props) => {
   const {
     color = "informative",
     size = "m",
-    isActive = true,
-    hasCloseButton = false,
+    hasButton = false,
     children
   } = props
 
   wrapperClasses.push(`-color-${color}`)
   wrapperClasses.push(`-size-${size}`)
-
-  if (hasCloseButton === false || isActive === true) {
-    wrapperClasses.push(`--active`)
-  }
 
   return (
     <div
@@ -38,7 +32,7 @@ const Callout: FC<Props> = (props: Props) => {
       <div className="_body">
         { children }
       </div>
-      { hasCloseButton && (
+      { hasButton && (
         <div className="_trailing">
           <button className="in-button -size-s -appearance-transparent">
             <div className="_body">閉じる</div>

--- a/packages/stories-web/src/components/Callout.tsx
+++ b/packages/stories-web/src/components/Callout.tsx
@@ -24,10 +24,7 @@ const Callout: FC<Props> = (props: Props) => {
   wrapperClasses.push(`-size-${size}`)
 
   return (
-    <div
-      className={wrapperClasses.join(' ')}
-      aria-live="polite"
-    >
+    <div className={wrapperClasses.join(' ')}>
       <span className="_leading in-icon"></span>
       <div className="_body">
         { children }


### PR DESCRIPTION
snackbarコンポーネントを参考に、calloutコンポーネントにcloseボタンを追加します。

bodyが1行だった場合に上下方向のズレが発生しますが、複数行になった際を考慮し上下中央揃えは追加せず、利用する際に追加してもらう方針としました。

|1行|複数行|
| --- | --- |
| <img width="534" alt="スクリーンショット 2025-01-20 19 43 11" src="https://github.com/user-attachments/assets/feb06add-757d-478e-86ce-1e03de1a7478" /> | <img width="534" alt="スクリーンショット 2025-01-20 19 44 14" src="https://github.com/user-attachments/assets/b19267b1-247f-4515-b2b8-517f0e99ee67" /> |
| <img width="534" alt="スクリーンショット 2025-01-20 19 43 54" src="https://github.com/user-attachments/assets/d492952a-eebc-4010-86f1-80c1a134be54" /> | <img width="534" alt="スクリーンショット 2025-01-20 19 44 35" src="https://github.com/user-attachments/assets/f5850814-eeef-4e41-9a62-7e4b32a3546e" /> |

