### PR TITLE
 Inhouseのラジオボタンの中央揃えを修正する

### DIFF
--- a/packages/radio/_mixins.scss
+++ b/packages/radio/_mixins.scss
@@ -110,10 +110,10 @@
 
   width: adapter.get-radio-child-background-width();
   height: adapter.get-radio-child-background-height();
-  transform: translate(-50%, -50%);
   background-color: adapter.get-radio-surface-color();
   border-radius: 50%;
   box-shadow: functions.get-background-box-shadow($states: $states);
+  transform: translate(-50%, -50%);
   content: "";
 }
 
@@ -125,11 +125,11 @@
 
   width: $foreground-size;
   height: $foreground-size;
-  transform: translate(-50%, -50%);
   color: adapter.get-radio-text-color($states: $states);
   font-size: $foreground-size;
   line-height: $foreground-size;
   text-align: center;
+  transform: translate(-50%, -50%);
   content: "circle";
   pointer-events: none;
 }

--- a/packages/radio/_mixins.scss
+++ b/packages/radio/_mixins.scss
@@ -110,14 +110,7 @@
 
   width: adapter.get-radio-child-background-width();
   height: adapter.get-radio-child-background-height();
-  margin-top:
-    functions.compose-child-element-margin(
-      $child-element-size: adapter.get-radio-child-background-height()
-    );
-  margin-left:
-    functions.compose-child-element-margin(
-      $child-element-size: adapter.get-radio-child-background-width()
-    );
+  transform: translate(-50%, -50%);
   background-color: adapter.get-radio-surface-color();
   border-radius: 50%;
   box-shadow: functions.get-background-box-shadow($states: $states);
@@ -132,8 +125,7 @@
 
   width: $foreground-size;
   height: $foreground-size;
-  margin-top: functions.compose-child-element-margin($child-element-size: $foreground-size);
-  margin-left: functions.compose-child-element-margin($child-element-size: $foreground-size);
+  transform: translate(-50%, -50%);
   color: adapter.get-radio-text-color($states: $states);
   font-size: $foreground-size;
   line-height: $foreground-size;


### PR DESCRIPTION
ラジオボタン内の選択されている状態を示す青い円が、文字サイズによって上寄りに表示されていたため、修正しました。


|bedore|after|
|--|--|
|<img width="149" alt="スクリーンショット 2025-03-27 14 28 25" src="https://github.com/user-attachments/assets/fc07b0a7-5175-4d14-afe2-2e2a7359da61" />|<img width="115" alt="スクリーンショット 2025-03-27 14 29 56" src="https://github.com/user-attachments/assets/2825085e-d284-4c1a-9ac6-7a0e37d287d3" />|
