### PR TITLE
scrimにexport mixinを追加

### DIFF
--- a/packages/components-web/_index.scss
+++ b/packages/components-web/_index.scss
@@ -18,6 +18,7 @@
 @forward "@pepabo-inhouse/navigation-drawer" as navigation-drawer-*;
 @forward "@pepabo-inhouse/progress-indicator" as progress-indicator-*;
 @forward "@pepabo-inhouse/radio" as radio-*;
+@forward "@pepabo-inhouse/scrim" as scrim-*;
 @forward "@pepabo-inhouse/select" as select-*;
 @forward "@pepabo-inhouse/side-navigation" as side-navigation-*;
 @forward "@pepabo-inhouse/skeleton" as skeleton-*;

--- a/packages/components-web/inhouse-components-web.scss
+++ b/packages/components-web/inhouse-components-web.scss
@@ -44,6 +44,7 @@
 @include navigation-drawer.export;
 @include progress-indicator.export;
 @include radio.export;
+@include scrim.export;
 @include select.export;
 @include side-navigation.export;
 @include table.export;

--- a/packages/scrim/_index.scss
+++ b/packages/scrim/_index.scss
@@ -1,1 +1,1 @@
-@forward "./mixins" show style;
+@forward "./mixins" show style, export;

--- a/packages/scrim/_mixins.scss
+++ b/packages/scrim/_mixins.scss
@@ -29,3 +29,9 @@
     }
   }
 }
+
+@mixin export {
+  .in-scrim {
+    @include style;
+  }
+}


### PR DESCRIPTION
一部のライブラリ（headless UI libraryなど）での実装にスタイルを適用しやすくするため、scrim単体でclassベースでも使えるようにexportのmixinを追加しました。