### PR TITLE
validation-messageコンポーネントを追加します

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31162,6 +31162,7 @@
       }
     },
     "packages/validation-message": {
+      "name": "@pepabo-inhouse/validation-message",
       "version": "3.4.0",
       "dependencies": {
         "@pepabo-inhouse/adapter": "^3.4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4502,6 +4502,10 @@
       "resolved": "https://registry.npmjs.org/@pepabo-inhouse/tokens/-/tokens-2.4.0.tgz",
       "integrity": "sha512-nh03PidYJyXQmR4MlawpVEjclLMW3cDxDLx1l1Eq6LjyQ4M9TFmo+2yDgC6NvwA1I1nfQCR8tdYtmr2zH7jpYA=="
     },
+    "node_modules/@pepabo-inhouse/validation-message": {
+      "resolved": "packages/validation-message",
+      "link": true
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -30824,6 +30828,7 @@
         "@pepabo-inhouse/textfield": "^3.4.0",
         "@pepabo-inhouse/thumbnail": "^3.4.0",
         "@pepabo-inhouse/tokens": "^2.4.0",
+        "@pepabo-inhouse/validation-message": "^3.4.0",
         "autoprefixer": "10.4.14",
         "cssnano": "5.1.15",
         "postcss": "^8.4.38",
@@ -31090,6 +31095,7 @@
         "@pepabo-inhouse/textfield": "^3.4.0",
         "@pepabo-inhouse/thumbnail": "^3.4.0",
         "@pepabo-inhouse/tokens": "^2.4.0",
+        "@pepabo-inhouse/validation-message": "^3.4.0",
         "@storybook/addon-essentials": "^7.0.6",
         "@storybook/react": "^7.0.6",
         "@storybook/react-webpack5": "^7.0.6",
@@ -31151,6 +31157,17 @@
         "@pepabo-inhouse/skeleton": "^3.4.0"
       },
       "devDependencies": {
+        "@pepabo-inhouse/flavor": "^3.4.0",
+        "@pepabo-inhouse/tokens": "^2.4.0"
+      }
+    },
+    "packages/validation-message": {
+      "version": "3.4.0",
+      "dependencies": {
+        "@pepabo-inhouse/adapter": "^3.4.0"
+      },
+      "devDependencies": {
+        "@pepabo-inhouse/constants": "^3.4.0",
         "@pepabo-inhouse/flavor": "^3.4.0",
         "@pepabo-inhouse/tokens": "^2.4.0"
       }

--- a/packages/components-web/_index.scss
+++ b/packages/components-web/_index.scss
@@ -25,3 +25,4 @@
 @forward "@pepabo-inhouse/table" as table-*;
 @forward "@pepabo-inhouse/textfield" as textfield-*;
 @forward "@pepabo-inhouse/snackbar" as snackbar-*;
+@forward "@pepabo-inhouse/validation-message" as validation-message-*;

--- a/packages/components-web/inhouse-components-web.scss
+++ b/packages/components-web/inhouse-components-web.scss
@@ -24,6 +24,7 @@
 @use "@pepabo-inhouse/table";
 @use "@pepabo-inhouse/textfield";
 @use "@pepabo-inhouse/snackbar";
+@use "@pepabo-inhouse/validation-message";
 
 // @import が存在しているので最初に flavor を読む
 // see: https://git.pepabo.com/inhouse/components-web/issues/355
@@ -51,3 +52,4 @@
 @include table.export;
 @include textfield.export;
 @include snackbar.export;
+@include validation-message.export;

--- a/packages/components-web/package.json
+++ b/packages/components-web/package.json
@@ -43,6 +43,7 @@
     "@pepabo-inhouse/textfield": "^3.4.0",
     "@pepabo-inhouse/thumbnail": "^3.4.0",
     "@pepabo-inhouse/tokens": "^2.4.0",
+    "@pepabo-inhouse/validation-message": "^3.4.0",
     "autoprefixer": "10.4.14",
     "cssnano": "5.1.15",
     "postcss": "^8.4.38",

--- a/packages/stories-web/package.json
+++ b/packages/stories-web/package.json
@@ -45,6 +45,7 @@
     "@pepabo-inhouse/textfield": "^3.4.0",
     "@pepabo-inhouse/thumbnail": "^3.4.0",
     "@pepabo-inhouse/tokens": "^2.4.0",
+    "@pepabo-inhouse/validation-message": "^3.4.0",
     "@storybook/addon-essentials": "^7.0.6",
     "@storybook/react": "^7.0.6",
     "@storybook/react-webpack5": "^7.0.6",

--- a/packages/stories-web/src/components/TextField.tsx
+++ b/packages/stories-web/src/components/TextField.tsx
@@ -1,5 +1,11 @@
 import React, { FC, InputHTMLAttributes, TextareaHTMLAttributes } from 'react';
 import { Appearance, SemanticColor, Size, State, Width } from './types';
+import {
+  TextField as AriaTextField,
+  Input as AriaInput,
+  TextArea as AriaTextArea,
+  FieldError as AriaFieldError
+} from 'react-aria-components';
 
 type HTMLProps = InputHTMLAttributes<HTMLInputElement> &
   TextareaHTMLAttributes<HTMLInputElement>;
@@ -8,6 +14,7 @@ export interface Props extends Omit<HTMLProps, 'size'> {
   appearance?: Extract<Appearance, 'outlined' | 'filled'>;
   color?: Extract<SemanticColor, 'neutral' | 'negative'>;
   htmlSize?: number;
+  isRequired?: boolean;
   size?: Extract<Size, 's' | 'm' | 'l'>;
   state?: Extract<State, 'enabled' | 'hover' | 'focused' | 'disabled'>;
   tag?: 'input' | 'textarea';
@@ -19,6 +26,7 @@ const TextField: FC<Props> = (props: Props) => {
     appearance,
     color,
     htmlSize,
+    isRequired,
     size,
     state,
     tag = 'input',
@@ -50,29 +58,34 @@ const TextField: FC<Props> = (props: Props) => {
     wrapperClasses.push(`-width-${width}`);
   }
 
-  if (tag === 'input') {
-    return (
-      <div className={wrapperClasses.join(' ')}>
-        <input
+  return (
+    <AriaTextField
+      value={value?.toString()}
+      isDisabled={state === 'disabled'}
+      isRequired={isRequired}
+      className={wrapperClasses.join(' ')}
+    >
+      {tag === 'input' ? (
+        <AriaInput
           className={innerClasses.join(' ')}
           size={htmlSize}
           type="text"
-          value={value}
           {...(rest as InputHTMLAttributes<HTMLInputElement>)}
         />
-      </div>
-    );
-  }
-
-  return (
-    <div className={wrapperClasses.join(' ')}>
-      <textarea
-        className={innerClasses.join(' ')}
-        {...(rest as TextareaHTMLAttributes<HTMLTextAreaElement>)}
-      >
-        {value}
-      </textarea>
-    </div>
+      ) : (
+        <AriaTextArea
+          className={innerClasses.join(' ')}
+          {...(rest as TextareaHTMLAttributes<HTMLTextAreaElement>)}
+        />
+      )}
+      <AriaFieldError className="in-validation-message -color-negative">
+        {({ validationDetails }) =>
+          validationDetails.valueMissing
+            ? '必須項目です'
+            : ''
+        }
+      </AriaFieldError>
+    </AriaTextField>
   );
 };
 

--- a/packages/stories-web/src/components/ValidationMessage.tsx
+++ b/packages/stories-web/src/components/ValidationMessage.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react'
+import { SemanticColor } from './types';
+
+export interface Props {
+  children: string;
+  color?: Extract<SemanticColor, "negative" | "neutral">;
+}
+
+const ValidationMessage: FC<Props> = (props: Props) => {
+  const wrapperClasses = ['in-validation-message']
+  const {
+    color,
+    children
+  } = props
+
+  wrapperClasses.push(`-color-${color}`)
+
+  return (
+    <span className={wrapperClasses.join(' ')}>
+      {children}
+    </span>
+  )
+}
+
+export default ValidationMessage

--- a/packages/stories-web/src/components/ValidationMessage.tsx
+++ b/packages/stories-web/src/components/ValidationMessage.tsx
@@ -3,7 +3,7 @@ import { SemanticColor } from './types';
 
 export interface Props {
   children: string;
-  color?: Extract<SemanticColor, "negative" | "neutral">;
+  color?: SemanticColor;
 }
 
 const ValidationMessage: FC<Props> = (props: Props) => {

--- a/packages/stories-web/src/components/demo/TextFieldDemo.tsx
+++ b/packages/stories-web/src/components/demo/TextFieldDemo.tsx
@@ -9,16 +9,16 @@ export type Props = Pick<
 const TextFieldDemo: FC<Props> = (props) => (
   <>
     <div>
-      <TextField {...props} />
-      <TextField {...props} state="hover" />
-      <TextField {...props} state="focused" />
-      <TextField {...props} state="disabled" disabled />
+      <TextField {...props} isRequired />
+      <TextField {...props} isRequired state="hover" />
+      <TextField {...props} isRequired state="focused" />
+      <TextField {...props} isRequired state="disabled" disabled />
     </div>
     <div>
-      <TextField {...props} tag="textarea" />
-      <TextField {...props} tag="textarea" state="hover" />
-      <TextField {...props} tag="textarea" state="focused" />
-      <TextField {...props} tag="textarea" state="disabled" disabled />
+      <TextField {...props} isRequired tag="textarea" />
+      <TextField {...props} isRequired tag="textarea" state="hover" />
+      <TextField {...props} isRequired tag="textarea" state="focused" />
+      <TextField {...props} isRequired tag="textarea" state="disabled" disabled />
     </div>
   </>
 );

--- a/packages/stories-web/src/validation-message.stories.tsx
+++ b/packages/stories-web/src/validation-message.stories.tsx
@@ -1,0 +1,16 @@
+import type { StoryFn, Meta } from '@storybook/react'
+import React from 'react'
+import ValidationMessage, { Props } from './components/ValidationMessage'
+
+export default {
+  title: 'Components/Validation Message',
+  component: ValidationMessage,
+} as Meta
+
+const Template: StoryFn<Props> = (args) => <ValidationMessage {...args} />
+
+export const Index = Template.bind({})
+Index.args = {
+  children: '必須項目です',
+  color: 'negative',
+}

--- a/packages/textfield/_mixins.scss
+++ b/packages/textfield/_mixins.scss
@@ -14,9 +14,7 @@
   $options: map.merge(variables.$default-option, $options);
 
   position: relative;
-  display: inline-flex;
-  flex-direction: column;
-  gap: adapter.get-gap-size($level: xxs);
+  display: inline-block;
   box-sizing: border-box;
 
   // width

--- a/packages/textfield/_mixins.scss
+++ b/packages/textfield/_mixins.scss
@@ -196,6 +196,13 @@
   }
 }
 
+@mixin -invalid-rule {
+  &[aria-invalid="true"],
+  &:user-invalid {
+    @content;
+  }
+}
+
 @mixin -appearance-rule($appearance: outlined, $intention: neutral) {
   @if $appearance == outlined {
     ._input {
@@ -217,6 +224,13 @@
         outline: adapter.get-focus-ring-outline();
         outline-offset: adapter.get-focus-ring-outline-offset();
       }
+
+      @include -invalid-rule {
+        box-shadow: inset 0 0 0 #{adapter.get-border-size($level: m)} #{adapter.get-field-border-color(
+            $color: negative,
+            $state: enabled
+          )};
+      }
     }
   } @else if $appearance == filled {
     ._input {
@@ -237,6 +251,13 @@
       @include -focus-rule {
         outline: adapter.get-focus-ring-outline();
         outline-offset: adapter.get-focus-ring-outline-offset();
+      }
+
+      @include -invalid-rule {
+        box-shadow: inset 0 #{0 - adapter.get-border-size($level: m)} 0 0 #{adapter.get-field-border-color(
+            $color: negative,
+            $state: enabled
+          )};
       }
     }
   }

--- a/packages/textfield/_mixins.scss
+++ b/packages/textfield/_mixins.scss
@@ -14,7 +14,9 @@
   $options: map.merge(variables.$default-option, $options);
 
   position: relative;
-  display: inline-block;
+  display: inline-flex;
+  flex-direction: column;
+  gap: adapter.get-gap-size($level: xxs);
   box-sizing: border-box;
 
   // width

--- a/packages/validation-message/README.md
+++ b/packages/validation-message/README.md
@@ -1,0 +1,13 @@
+# Inhouse Validation Message
+
+## Usage
+
+### Installation
+
+```bash
+$ npm install @pepabo-inhouse/validation-message
+
+# or
+
+$ yarn add @pepabo-inhouse/validation-message
+```

--- a/packages/validation-message/_index.scss
+++ b/packages/validation-message/_index.scss
@@ -1,0 +1,1 @@
+@forward "./mixins" show style, export;

--- a/packages/validation-message/_mixins.scss
+++ b/packages/validation-message/_mixins.scss
@@ -6,7 +6,7 @@
 @mixin style($options: variables.$default-option) {
   @include adapter.text(
     $level: s,
-    $density: normal
+    $density: dense
   );
   @include -color-rule(map.get($options, intention));
 

--- a/packages/validation-message/_mixins.scss
+++ b/packages/validation-message/_mixins.scss
@@ -10,7 +10,7 @@
   );
   @include -color-rule(map.get($options, intention));
 
-  @each $intention in variables.$available-semantic-intentions {
+  @each $intention in adapter.get-semantic-intentions() {
     &.-color-#{$intention} {
       @include -color-rule($intention: $intention);
     }
@@ -24,9 +24,17 @@
 }
 
 @mixin -color-rule($intention: negative) {
-  @if $intention == negative {
-    color: adapter.get-semantic-color($intention: negative, $level: 600);
+  @if $intention == informative {
+    color: adapter.get-semantic-color($intention: informative, $level: 600);
   } @else if $intention == neutral {
     color: adapter.get-semantic-color($intention: neutral, $level: 600);
+  } @else if $intention == positive {
+    color: adapter.get-semantic-color($intention: positive, $level: 600);
+  } @else if $intention == notice {
+    color: adapter.get-semantic-color($intention: notice, $level: 600);
+  } @else if $intention == negative {
+    color: adapter.get-semantic-color($intention: negative, $level: 600);
+  } @else if $intention == attention {
+    color: adapter.get-semantic-color($intention: attention, $level: 600);
   }
 }

--- a/packages/validation-message/_mixins.scss
+++ b/packages/validation-message/_mixins.scss
@@ -1,0 +1,32 @@
+@use "sass:map";
+@use "sass:list";
+@use "@pepabo-inhouse/adapter" as adapter;
+@use "./variables";
+
+@mixin style($options: variables.$default-option) {
+  @include adapter.text(
+    $level: s,
+    $density: normal
+  );
+  @include -color-rule(map.get($options, intention));
+
+  @each $intention in variables.$available-semantic-intentions {
+    &.-color-#{$intention} {
+      @include -color-rule($intention: $intention);
+    }
+  }
+}
+
+@mixin export {
+  .in-validation-message {
+    @include style;
+  }
+}
+
+@mixin -color-rule($intention: negative) {
+  @if $intention == negative {
+    color: adapter.get-semantic-color($intention: negative, $level: 600);
+  } @else if $intention == neutral {
+    color: adapter.get-semantic-color($intention: neutral, $level: 600);
+  }
+}

--- a/packages/validation-message/_variables.scss
+++ b/packages/validation-message/_variables.scss
@@ -1,0 +1,7 @@
+$default-option: (
+  intention: neutral
+);
+$available-semantic-intentions: (
+  neutral,
+  negative
+);

--- a/packages/validation-message/_variables.scss
+++ b/packages/validation-message/_variables.scss
@@ -1,7 +1,3 @@
 $default-option: (
   intention: neutral
 );
-$available-semantic-intentions: (
-  neutral,
-  negative
-);

--- a/packages/validation-message/inhouse-validation-message.scss
+++ b/packages/validation-message/inhouse-validation-message.scss
@@ -1,0 +1,2 @@
+@use "./mixins";
+@include mixins.export;

--- a/packages/validation-message/package.json
+++ b/packages/validation-message/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@pepabo-inhouse/validation-message",
+  "description": "Inhouse Components for the web component",
+  "version": "3.4.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pepabo/inhouse-components-web.git",
+    "directory": "packages/validation-message"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pepabo-inhouse/adapter": "^3.4.0"
+  },
+  "devDependencies": {
+    "@pepabo-inhouse/constants": "^3.4.0",
+    "@pepabo-inhouse/flavor": "^3.4.0",
+    "@pepabo-inhouse/tokens": "^2.4.0"
+  }
+}


### PR DESCRIPTION
## validation-messageコンポーネントを追加
![スクリーンショット 2025-05-13 17 57 31](https://github.com/user-attachments/assets/c5c9d410-1661-4fd1-840d-53a0ae88d4d9)

- `color` props を設定できるようにしました

## TextFieldDemoを更新
<img width="968" alt="スクリーンショット 2025-05-13 11 08 27" src="https://github.com/user-attachments/assets/b4e3cea4-87ae-4965-b890-65ffa531818d" />

- React Ariaを利用しました
  - 事例として必須項目のTextFieldに変更しました
  - 事例としてuser-invalid 時にvalidation-messageコンポーネントを表示するように変更しました


## TextFieldコンポーネントを更新
- user-invalid な時、negativeのcolorを適用するように調整しました
- validation-message等が追加されても余白が適切になるように調整しました
