### PR TITLE
CircularProgressIndicatorの色にcurrentColorが反映されるよう調整

### DIFF
--- a/packages/progress-indicator/_mixins.scss
+++ b/packages/progress-indicator/_mixins.scss
@@ -75,7 +75,7 @@
 
   &.-is-parent-color {
     &::after {
-      border-color: currentColor;
+      border-color: currentcolor;
     }
   }
 

--- a/packages/progress-indicator/_mixins.scss
+++ b/packages/progress-indicator/_mixins.scss
@@ -73,6 +73,12 @@
     clip-path: polygon(0% 0%, 0% 100%, 100% 100%, 100% 0%, 0% 0%, 50% 50%);
   }
 
+  &.-is-parent-color {
+    &::after {
+      border-color: currentColor;
+    }
+  }
+
   @each $size in "s", "m", "l" {
     &.-size-#{$size} {
       @include -size-style($size);

--- a/packages/stories-web/src/components/progress-indicator/Circular.tsx
+++ b/packages/stories-web/src/components/progress-indicator/Circular.tsx
@@ -5,6 +5,7 @@ export interface Props {
   max: number
   value?: number
   size?: Extract<Size, 's' | 'm' | 'l'>
+  isParentColor?: boolean
 }
 
 const Circular: FC<Props> = (props: Props) => {
@@ -12,6 +13,7 @@ const Circular: FC<Props> = (props: Props) => {
     max,
     value,
     size,
+    isParentColor,
     ...rest
   } = props
 
@@ -26,6 +28,10 @@ const Circular: FC<Props> = (props: Props) => {
     percentage = Math.round(value / max * 100)
   } else {
     percentage = Math.round(max / max * 100)
+  }
+
+  if (isParentColor) {
+    classes.push("-is-parent-color");
   }
 
   return (


### PR DESCRIPTION
ボタン上にCircularProgressIndicatorを配置した際に、ボタンの背景色と同化してしまっていたため、CircularProgressIndicatorにcurrentColorを追加し、背景色に合った色を継承することができるように修正しました。

|before|after|
|--|--|
|<img width="534" alt="スクリーンショット 2025-05-19 15 52 39" src="https://github.com/user-attachments/assets/e842de3d-a0c2-487a-8f55-7a62569d505b" />|<img width="527" alt="スクリーンショット 2025-05-19 15 51 46" src="https://github.com/user-attachments/assets/565acbd8-acd4-4acc-9fd9-2a5a4da05cc8" />|