### PR TITLE
heightがtextareaに適用されないようinputだけに適用

### DIFF
--- a/packages/textfield/_mixins.scss
+++ b/packages/textfield/_mixins.scss
@@ -166,11 +166,14 @@
 
 @mixin -size-rule($level: m) {
   ._input {
-    height: adapter.get-interactive-component-height($level: $level);
     padding: #{(adapter.get-interactive-component-height($level: $level) * 0.5) -
       (adapter.get-line-height($level: $level, $density: normal) * 0.5)}
       adapter.get-spacing-size($level: $level);
     font-size: adapter.get-font-size($level: $level);
+  }
+
+  input._input {
+    height: adapter.get-interactive-component-height($level: $level);
   }
 
   textarea._input {


### PR DESCRIPTION
textfieldのheightプロパティをinput要素に限定して適用するように変更しました。
heightがinput要素, textarea要素を問わず適用されているため、textarea要素の高さがheightの値で固定されrows属性が効かなくなっているのを解消します。

|変更前|変更後|
|:--:|:--:|
|<img width="300" alt="同じ1行分の高さのinputとtextareaが並んだキャプチャ" src="https://github.com/user-attachments/assets/b77ae6b0-8ded-4d89-a941-8a1991e52ab5">|<img width="300" alt="1行分の高さのinputと複数行分の高さのtextareaが並んだキャプチャ" src="https://github.com/user-attachments/assets/7bb09ece-000c-4a28-8659-382709a371c0">|


