### PR TITLE
SassDocのURLをREADMEに書きます

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@
 ### Storybook
 [inhouse-components-web](https://pepabo.github.io/inhouse-components-web)
 
+### SassDoc
+
+[adapter](https://pepabo.github.io/inhouse-components-web/adapter/)
+
 ## Customization
 
 components-web にはビルド済みの production ready な CSS とは別で、 Sass と NPM を使った flavor によるカスタマイズの仕組みが備わっています。

--- a/packages/adapter/README.md
+++ b/packages/adapter/README.md
@@ -5,11 +5,9 @@
 ### Installation
 
 ```bash
-$ npm install git+ssh://git@git.pepabo.com/inhouse/adapter.git#version
+$ npm install @pepabo-inhouse/adapter
 
 # or
 
-$ yarn add git+ssh://git@git.pepabo.com/inhouse/adapter.git#version
+$ yarn add @pepabo-inhouse/adapter
 ```
-
-`version` は https://git.pepabo.com/inhouse/adapter/releases にあるリリースタグを指定します。

--- a/packages/components-web/inhouse-components-web.scss
+++ b/packages/components-web/inhouse-components-web.scss
@@ -25,8 +25,9 @@
 @use "@pepabo-inhouse/textfield";
 @use "@pepabo-inhouse/snackbar";
 
-// @import が存在しているので最初に flavor を読む
-// see: https://git.pepabo.com/inhouse/components-web/issues/355
+// flavor内で@import が存在しているので最初に flavor を読む
+// @import はCSSの先頭で宣言されている必要がある
+// see: https://www.w3.org/TR/css-cascade-3/#at-import
 @include flavor.export;
 @include app-bar.export;
 @include avatar.export;


### PR DESCRIPTION
SassDocのURLをREADMEに書くことで、アクセスしてもらえるようにします。

また、ついでに情報が古くなったドキュメントを更新しました