### PR TITLE
docs: adapterパッケージのmixinにSassdocを追加

### DIFF
--- a/packages/adapter/_mixins.scss
+++ b/packages/adapter/_mixins.scss
@@ -1,15 +1,55 @@
 @use "sass:map";
 @use "./functions";
 
+/// テキストのフォントサイズと行間を設定するmixin
+/// @group typography
+/// @param {String} $level [m] - フォントサイズのレベル（xxs, xs, s, m, l, xl, xxl, xxxl）
+/// @param {String} $density [normal] - 行間の密度（dense, normal, comfort）
+/// @example scss - 基本的な使用例
+///   .text {
+///     @include text($level: l, $density: comfort);
+///   }
+/// @example scss - デフォルト値での使用
+///   .text {
+///     @include text();
+///   }
 @mixin text($level: m, $density: normal) {
   font-size: functions.get-font-size($level: $level);
   line-height: functions.get-line-height($level: $level, $density: $density);
 }
 
+/// 要素にelevation（影）を適用するmixin
+/// @group shadow
+/// @param {Number} $level [1] - elevationのレベル（0-6）
+/// @example scss - 基本的な使用例
+///   .card {
+///     @include elevation($level: 2);
+///   }
+/// @example scss - デフォルト値での使用
+///   .card {
+///     @include elevation();
+///   }
 @mixin elevation($level: 1) {
   box-shadow: functions.get-elevation-box-shadow($level: $level);
 }
 
+/// メディアクエリのブレークポイントを設定するmixin
+/// @group responsive
+/// @param {String} $name - メディアクエリの方向（up または down）
+/// @param {String} $level - ブレークポイントのレベル（xxs, xs, s, m, l, xl）
+/// @content スタイルルール
+/// @example scss - 画面幅がm以上の場合のスタイル
+///   .container {
+///     @include mq-boundary(up, m) {
+///       max-width: 960px;
+///     }
+///   }
+/// @example scss - 画面幅がs以下の場合のスタイル
+///   .sidebar {
+///     @include mq-boundary(down, s) {
+///       display: none;
+///     }
+///   }
 @mixin mq-boundary($name, $level) {
   @if $name == up {
     @media screen and (min-width: functions.get-boundary-size($level)) {


### PR DESCRIPTION
## 概要
adapterパッケージの`_mixins.scss`にSassdocコメントを追加し、ドキュメントサイトでmixinの詳細情報を確認できるようにしました。

## 変更内容
- `text` mixin: フォントサイズと行間を設定するmixinにSassdocを追加
- `elevation` mixin: 要素に影を適用するmixinにSassdocを追加  
- `mq-boundary` mixin: メディアクエリのブレークポイントを設定するmixinにSassdocを追加

## 期待する結果
- https://pepabo.github.io/inhouse-components-web/adapter/ でmixinの詳細情報が確認可能
- 各mixinのパラメータ説明と使用例が日本語で表示される
- 開発者がmixinの正しい使い方を素早く理解できる

## 影響範囲
- ドキュメントサイトのみ（実装コードに変更なし）
- 既存の機能に影響なし

author: AI
