### PR TITLE
Calloutのsizeに関するスタイルを調整

### DIFF
--- a/packages/callout/_mixins.scss
+++ b/packages/callout/_mixins.scss
@@ -6,6 +6,7 @@
 
 @mixin style($options: variables.$default-options) {
   $options: map.merge(variables.$default-options, $options);
+
   display: flex;
   gap: adapter.get-spacing-size(s);
   box-shadow: adapter.get-elevation-box-shadow(1);
@@ -73,21 +74,21 @@
 }
 
 @mixin -size-style($size) {
-    padding-block: calc(adapter.get-spacing-size($size) / 2);
-    padding-inline: adapter.get-spacing-size($size) calc(adapter.get-spacing-size($size) / 2);
-    border-radius: adapter.get-radius-size($size);
+  padding-block: calc(adapter.get-spacing-size($size) / 2);
+  padding-inline: adapter.get-spacing-size($size) calc(adapter.get-spacing-size($size) / 2);
+  border-radius: adapter.get-radius-size($size);
 
   ._leading {
+    font-size: adapter.get-font-size($size);
     line-height: adapter.get-line-height($level: $size, $density: normal);
     padding-block: calc((adapter.get-interactive-component-height($level: $size) - adapter.get-line-height($level: $size, $density: normal)) / 2);
-    font-size: adapter.get-font-size($size);
   }
 
   ._body {
+    gap: adapter.get-spacing-size(map.get(variables.$title-margin-map, $size));
+    font-size: adapter.get-font-size($size);
     line-height: adapter.get-line-height($level: $size, $density: normal);
     padding-block: calc((adapter.get-interactive-component-height($level: $size) - adapter.get-line-height($level: $size, $density: normal)) / 2);
-    font-size: adapter.get-font-size($size);
-    gap: adapter.get-spacing-size(map.get(variables.$title-margin-map, $size));
   }
 
   ._trailing {

--- a/packages/callout/_mixins.scss
+++ b/packages/callout/_mixins.scss
@@ -92,7 +92,7 @@
   }
 
   ._trailing {
-    ._button {
+    ._action {
       @include button.style(
         $options: (
           size: $size,

--- a/packages/callout/_mixins.scss
+++ b/packages/callout/_mixins.scss
@@ -1,25 +1,23 @@
 @use "sass:map";
 @use "sass:list";
 @use "@pepabo-inhouse/adapter/functions" as adapter;
+@use "@pepabo-inhouse/button" as button;
 @use "./variables";
 
 @mixin style($options: variables.$default-options) {
-  display: flex;
-  padding: adapter.get-spacing-size(map.get($options, size));
-  font-size: adapter.get-font-size(map.get($options, size));
-  line-height: adapter.get-line-height($level: map.get($options, size), $density: normal);
-  border-radius: adapter.get-radius-size(map.get($options, size));
-  box-shadow: adapter.get-elevation-box-shadow(1);
   $options: map.merge(variables.$default-options, $options);
+  display: flex;
+  gap: adapter.get-spacing-size(s);
+  box-shadow: adapter.get-elevation-box-shadow(1);
 
   ._leading {
-    padding-right: adapter.get-spacing-size(s);
     line-height: inherit;
   }
 
   ._body {
     display: flex;
     flex-direction: column;
+    justify-content: center;
     margin: 0;
   }
 
@@ -75,11 +73,32 @@
 }
 
 @mixin -size-style($size) {
-  font-size: adapter.get-font-size($size);
-  line-height: adapter.get-line-height($level: $size, $density: normal);
+    padding-block: calc(adapter.get-spacing-size($size) / 2);
+    padding-inline: adapter.get-spacing-size($size) calc(adapter.get-spacing-size($size) / 2);
+    border-radius: adapter.get-radius-size($size);
+
+  ._leading {
+    line-height: adapter.get-line-height($level: $size, $density: normal);
+    padding-block: calc((adapter.get-interactive-component-height($level: $size) - adapter.get-line-height($level: $size, $density: normal)) / 2);
+    font-size: adapter.get-font-size($size);
+  }
 
   ._body {
+    line-height: adapter.get-line-height($level: $size, $density: normal);
+    padding-block: calc((adapter.get-interactive-component-height($level: $size) - adapter.get-line-height($level: $size, $density: normal)) / 2);
+    font-size: adapter.get-font-size($size);
     gap: adapter.get-spacing-size(map.get(variables.$title-margin-map, $size));
+  }
+
+  ._trailing {
+    ._button {
+      @include button.style(
+        $options: (
+          size: $size,
+          appearance: transparent,
+        )
+      );
+    }
   }
 }
 

--- a/packages/stories-web/src/components/Callout.tsx
+++ b/packages/stories-web/src/components/Callout.tsx
@@ -31,7 +31,7 @@ const Callout: FC<Props> = (props: Props) => {
       </div>
       { hasButton && (
         <div className="_trailing">
-          <button className="in-button -size-s -appearance-transparent">
+          <button className="_button">
             <div className="_body">閉じる</div>
           </button>
         </div>

--- a/packages/stories-web/src/components/Callout.tsx
+++ b/packages/stories-web/src/components/Callout.tsx
@@ -31,7 +31,7 @@ const Callout: FC<Props> = (props: Props) => {
       </div>
       { hasButton && (
         <div className="_trailing">
-          <button className="_button">
+          <button className="_action">
             <div className="_body">閉じる</div>
           </button>
         </div>


### PR DESCRIPTION
- calloutのtrailing itemとして配置されるbuttonのsizeを、calloutと別に指定しなくて済むようにしました
  - calloutにて指定したsizeにしたがって内包するbuttonのsizeも決定されます
  - 独立したbuttonとしての `.in-button` classから、calloutの内包要素としてbottom-navigationのように `._action` modifier classへ変更しました。
- 内包するbuttonのheightとなっているadapterの `get-interactive-component-height` を基準にleading iconとbodyを描画し、縦位置が綺麗に揃うようにしました。