### PR TITLE
button要素の内容はphrasing contentだけなのでflowのdiv要素はspan要素に変更

### DIFF
--- a/packages/stories-web/src/components/Callout.tsx
+++ b/packages/stories-web/src/components/Callout.tsx
@@ -32,7 +32,7 @@ const Callout: FC<Props> = (props: Props) => {
       { hasButton && (
         <div className="_trailing">
           <button className="_action">
-            <div className="_body">閉じる</div>
+            <span className="_body">閉じる</span>
           </button>
         </div>
       )}

--- a/packages/stories-web/src/components/Snackbar.tsx
+++ b/packages/stories-web/src/components/Snackbar.tsx
@@ -31,7 +31,7 @@ export const Snackbar: FC<Props> = ({
         <span>アイテム1を削除しました</span>
         <div className="_trailing">
           <button className="in-button -size-s -appearance-transparent">
-            <div className="_body">もとに戻す</div>
+            <span className="_body">もとに戻す</span>
           </button>
         </div>
       </div>

--- a/packages/stories-web/src/components/avatar/Avatar.tsx
+++ b/packages/stories-web/src/components/avatar/Avatar.tsx
@@ -22,7 +22,7 @@ const Avatar: FC<Props> = (props: Props) => {
   }
 
   return (
-    <div
+    <span
       className={classes.join(' ')}
       {...rest}
     >
@@ -30,7 +30,7 @@ const Avatar: FC<Props> = (props: Props) => {
         src={src}
         srcSet={srcSet}
       />
-    </div>
+    </span>
   );
 }
 

--- a/packages/stories-web/src/components/bottom-navigation/BottomNavigationItem.tsx
+++ b/packages/stories-web/src/components/bottom-navigation/BottomNavigationItem.tsx
@@ -75,13 +75,13 @@ const Inner: FC<InnerProps> = (props: InnerProps) => {
 
   return (
     <>
-      <div className='_icon'>
+      <span className='_icon'>
         {icon}
-      </div>
+      </span>
       {text && (
-        <div className='_text'>
+        <span className='_text'>
           {text}
-        </div>
+        </span>
       )}
     </>
   )

--- a/packages/stories-web/src/components/button/Button.tsx
+++ b/packages/stories-web/src/components/button/Button.tsx
@@ -70,19 +70,19 @@ const Button: FC<Props> = (props: Props) => {
       {...rest}
     >
       {leading && (
-        <div className='_leading'>
+        <span className='_leading'>
           {leading}
-        </div>
+        </span>
       )}
       {body && (
-        <div className='_body'>
+        <span className='_body'>
           {body}
-        </div>
+        </span>
       )}
       {trailing && (
-        <div className='_trailing'>
+        <span className='_trailing'>
           {trailing}
-        </div>
+        </span>
       )}
     </button>
   )

--- a/packages/stories-web/src/components/interactive-list/InteractiveListItem.tsx
+++ b/packages/stories-web/src/components/interactive-list/InteractiveListItem.tsx
@@ -256,28 +256,28 @@ const Inner: FC<InnerProps> = (props: InnerProps) => {
   return (
     <>
       {leading &&
-        <div className='_leading'>
-          <div className={leadingElementClasses.join(' ')}>
+        <span className='_leading'>
+          <span className={leadingElementClasses.join(' ')}>
             {leading}
-          </div>
-        </div>
+          </span>
+        </span>
       }
-      <div className='_body'>
-        <div className='_title'>
+      <span className='_body'>
+        <span className='_title'>
           {title}
-        </div>
+        </span>
         {description && (
-          <div className='_description'>
+          <span className='_description'>
             {description}
-          </div>
+          </span>
         )}
-      </div>
+      </span>
       {trailing &&
-        <div className='_trailing'>
-          <div className={`_${trailingElement}`}>
+        <span className='_trailing'>
+          <span className={`_${trailingElement}`}>
             {trailing}
-          </div>
-        </div>
+          </span>
+        </span>
       }
     </>
   )

--- a/packages/stories-web/src/components/interactive-list/Thumbnail.tsx
+++ b/packages/stories-web/src/components/interactive-list/Thumbnail.tsx
@@ -8,9 +8,9 @@ const Thumbnail :FC<Props> = (props: Props) => {
   const { children } = props
 
   return (
-    <div className='_thumbnail'>
+    <span className='_thumbnail'>
       {children}
-    </div>
+    </span>
   )
 }
 


### PR DESCRIPTION
Storybookの一部でbutton要素内にdiv要素を記述していたのですが、button要素の内容はphrasing contentのみで、flow contentのdiv要素は不適切なのでspan要素に変更しました。