### PR TITLE
avatarはsizeを直接指定するのでinline-blockに設定

### DIFF
--- a/packages/avatar/_mixins.scss
+++ b/packages/avatar/_mixins.scss
@@ -6,6 +6,7 @@
 @mixin style($option: variables.$default-option) {
   $option: map.merge(variables.$default-option, $option);
 
+  display: inline-block;
   box-sizing: border-box;
   width: adapter.get-avatar-width($level: map.get($option, size));
   height: adapter.get-avatar-height($level: map.get($option, size));


### PR DESCRIPTION
span要素などでマークアップされる場合にサイズが反映されない場合を想定してinline-blockをデフォルトとして備えておく