### PR TITLE
Fix Sass deprecated color functions

### DIFF
--- a/packages/adapter/functions/_helpers.scss
+++ b/packages/adapter/functions/_helpers.scss
@@ -468,9 +468,9 @@ $available-hexadecimal-chars: "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", 
 /// 輝度を計算する
 /// 参考: https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-tests
 @function -compose-luminance($color) {
-  $red: -compose-linear-channel-value(color.red($color));
-  $green: -compose-linear-channel-value(color.green($color));
-  $blue: -compose-linear-channel-value(color.blue($color));
+  $red: -compose-linear-channel-value(color.channel($color, "red", $space: rgb));
+  $green: -compose-linear-channel-value(color.channel($color, "green", $space: rgb));
+  $blue: -compose-linear-channel-value(color.channel($color, "blue", $space: rgb));
 
   @return 0.2126 * $red + 0.7152 * $green + 0.0722 * $blue;
 }


### PR DESCRIPTION
Replace color.red(), color.green(), color.blue() with color.channel() in packages/adapter/functions/_helpers.scss to resolve deprecation warnings in Sass 1.62.1+. No functional changes, WCAG 2.0 contrast ratio calculation works as expected.

🤖 Generated with [Claude Code](https://claude.ai/code)