### PR TITLE
Revert "Fix Sass deprecated color functions"

### DIFF
--- a/packages/adapter/functions/_helpers.scss
+++ b/packages/adapter/functions/_helpers.scss
@@ -468,9 +468,9 @@ $available-hexadecimal-chars: "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", 
 /// 輝度を計算する
 /// 参考: https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-tests
 @function -compose-luminance($color) {
-  $red: -compose-linear-channel-value(color.channel($color, "red", $space: rgb));
-  $green: -compose-linear-channel-value(color.channel($color, "green", $space: rgb));
-  $blue: -compose-linear-channel-value(color.channel($color, "blue", $space: rgb));
+  $red: -compose-linear-channel-value(color.red($color));
+  $green: -compose-linear-channel-value(color.green($color));
+  $blue: -compose-linear-channel-value(color.blue($color));
 
   @return 0.2126 * $red + 0.7152 * $green + 0.0722 * $blue;
 }


### PR DESCRIPTION
Reverts pepabo/inhouse-components-web#78

この変更によってビルドをパスしなくなっているようですので、一度巻き戻します。
https://sass-lang.com/documentation/modules/color/ によれば、1.79.0以上のバージョンのSassに依存すると解決するようですが、そのアップデートも含めて一度仕切り直したいです。