### PR TITLE
circular-progress-indicatorの実装方法を変更します

### DIFF
--- a/packages/progress-indicator/_functions.scss
+++ b/packages/progress-indicator/_functions.scss
@@ -1,5 +1,0 @@
-@use "sass:math";
-
-@function compose-polygon-displacement($var) {
-  @return 50% - (50% * math.tan(45deg - (($var % 25) * math.div(90,25))));
-}

--- a/packages/progress-indicator/_functions.test.scss
+++ b/packages/progress-indicator/_functions.test.scss
@@ -1,9 +1,0 @@
-@use "./functions";
-@use "@gyugyu/assert-sass" as assert;
-
-@function test-compose-polygon-displacement() {
-  @return assert.equals(
-    functions.compose-polygon-displacement(50),
-    0%
-  );
-}

--- a/packages/progress-indicator/_index.scss
+++ b/packages/progress-indicator/_index.scss
@@ -1,1 +1,1 @@
-@forward "./mixins" show linear, export;
+@forward "./mixins" show linear, circular, export;

--- a/packages/progress-indicator/_mixins.scss
+++ b/packages/progress-indicator/_mixins.scss
@@ -38,39 +38,39 @@
     }
 
     &::before {
-      animation: indeterminate 2.1s cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
+      animation: in-linear-indeterminate 2.1s cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
     }
 
     &::after {
-      animation: indeterminate-short 2.1s cubic-bezier(0.165, 0.84, 0.44, 1) infinite;
+      animation: in-linear-indeterminate-short 2.1s cubic-bezier(0.165, 0.84, 0.44, 1) infinite;
       animation-delay: 1.15s;
     }
   }
 }
 
-@property --circular-start-point {
+@property --in-circular-start-point {
   syntax: "<percentage>";
   inherits: false;
   initial-value: 0%;
 }
 
-@property --circular-percentage {
+@property --in-circular-percentage {
   syntax: "<percentage>";
   inherits: false;
   initial-value: 100%;
 }
 
 @mixin circular($option: variables.$default-option) {
-  --circular-color: #{adapter.get-progress-indicator-indicator-surface-color()};
-  --circular-size: #{adapter.get-progress-indicator-border-size($size: m)};
+  --in-circular-color: #{adapter.get-progress-indicator-indicator-surface-color()};
+  --in-circular-size: #{adapter.get-progress-indicator-border-size($size: m)};
 
   position: relative;
   width: adapter.get-circular-progress-indicator-width();
   height: adapter.get-circular-progress-indicator-height();
 
   &::after {
-    --circular-start-point: 0%;
-    --circular-percentage: 100%;
+    --in-circular-start-point: 0%;
+    --in-circular-percentage: 100%;
 
     position: absolute;
     inset: adapter.get-spacing-size($level: xxs);
@@ -79,28 +79,28 @@
     margin: auto;
     background:
       conic-gradient(
-        transparent var(--circular-start-point),
-        var(--circular-color) var(--circular-start-point),
-        var(--circular-color) var(--circular-percentage),
+        transparent var(--in-circular-start-point),
+        var(--in-circular-color) var(--in-circular-start-point),
+        var(--in-circular-color) var(--in-circular-percentage),
         transparent 0
       );
     border-radius: 50%;
     // stylelint-disable-next-line custom-property-no-missing-var-function
-    transition: --circular-percentage 0.1s ease;
+    transition: --in-circular-percentage 0.1s ease;
     content: "";
     mask-image:
       radial-gradient(
         closest-side,
-        transparent calc(100% - var(--circular-size) - 0.5px),
-        rgba(0, 0, 0, 50%) calc(100% - var(--circular-size) - 0.25px),
-        black calc(100% - var(--circular-size)) 100%
+        transparent calc(100% - var(--in-circular-size) - 0.5px),
+        rgba(0, 0, 0, 50%) calc(100% - var(--in-circular-size) - 0.25px),
+        black calc(100% - var(--in-circular-size)) 100%
       );
     aspect-ratio: 1;
   }
 
   &.-is-parent-color {
     &::after {
-      --circular-color: currentcolor;
+      --in-circular-color: currentcolor;
     }
   }
 
@@ -112,19 +112,19 @@
 
   @for $i from 0 to 100 {
     &[data-percentage="#{$i}"]::after {
-      --circular-percentage: #{$i * 1%};
+      --in-circular-percentage: #{$i * 1%};
     }
   }
 
   &:not([aria-valuenow]),
   &[aria-valuenow=""] {
     &::after {
-      animation: circular-indeterminate 2s linear infinite, circular-indeterminate-rotate 2s linear infinite;
+      animation: in-circular-indeterminate 2s linear infinite, in-circular-indeterminate-rotate 2s linear infinite;
     }
   }
 }
 
-@keyframes indeterminate {
+@keyframes in-linear-indeterminate {
   0% {
     right: 100%;
     left: -35%;
@@ -141,7 +141,7 @@
   }
 }
 
-@keyframes indeterminate-short {
+@keyframes in-linear-indeterminate-short {
   0% {
     right: 100%;
     left: -200%;
@@ -158,7 +158,7 @@
   }
 }
 
-@keyframes circular-indeterminate-rotate {
+@keyframes in-circular-indeterminate-rotate {
   0% {
     transform: rotate(0deg);
   }
@@ -168,26 +168,26 @@
   }
 }
 
-@keyframes circular-indeterminate {
+@keyframes in-circular-indeterminate {
   0% {
-    --circular-start-point: 0%;
-    --circular-percentage: 0%;
+    --in-circular-start-point: 0%;
+    --in-circular-percentage: 0%;
   }
 
   50% {
-    --circular-start-point: 0%;
-    --circular-percentage: 100%;
+    --in-circular-start-point: 0%;
+    --in-circular-percentage: 100%;
   }
 
   100% {
-    --circular-start-point: 100%;
-    --circular-percentage: 100%;
+    --in-circular-start-point: 100%;
+    --in-circular-percentage: 100%;
   }
 }
 
 @mixin -size-style($size) {
   &::after {
-    --circular-size: #{adapter.get-progress-indicator-border-size($size)};
+    --in-circular-size: #{adapter.get-progress-indicator-border-size($size)};
   }
 }
 

--- a/packages/progress-indicator/_mixins.scss
+++ b/packages/progress-indicator/_mixins.scss
@@ -49,33 +49,36 @@
   }
 }
 
+@property --circular-progress-indicator-percentage {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
 @mixin circular($option: variables.$default-option) {
+  --circular-progress-indicator-color: #{adapter.get-progress-indicator-indicator-surface-color()};
+
   position: relative;
   width: adapter.get-circular-progress-indicator-width();
   height: adapter.get-circular-progress-indicator-height();
 
   &::after {
+    --circular-progress-indicator-percentage: 100%;
+
     position: absolute;
-    top: adapter.get-spacing-size($level: xxs);
-    right: adapter.get-spacing-size($level: xxs);
-    bottom: adapter.get-spacing-size($level: xxs);
-    left: adapter.get-spacing-size($level: xxs);
+    inset: adapter.get-spacing-size($level: xxs);
     display: block;
     box-sizing: border-box;
-    border-color: adapter.get-progress-indicator-indicator-surface-color();
-    border-style: solid;
-    border-width: adapter.get-progress-indicator-border-size($size: l);
+    background: conic-gradient(var(--circular-progress-indicator-color) var(--circular-progress-indicator-percentage), transparent 0);
     border-radius: 50%;
-    transform: rotate(45deg);
-    transform-origin: center;
-    transition: clip-path 0.1s ease;
+    transition: --circular-progress-indicator-percentage 0.1s ease;
     content: "";
-    clip-path: polygon(0% 0%, 0% 100%, 100% 100%, 100% 0%, 0% 0%, 50% 50%);
+    mask-image: radial-gradient(closest-side, transparent 79%, black 80% 100%);
   }
 
   &.-is-parent-color {
     &::after {
-      border-color: currentcolor;
+      --circular-progress-indicator-color: currentcolor;
     }
   }
 
@@ -85,59 +88,9 @@
     }
   }
 
-  @for $i from 0 to 25 {
+  @for $i from 0 to 100 {
     &[data-percentage="#{$i}"]::after {
-      clip-path:
-        polygon(
-          functions.compose-polygon-displacement($i) 0%,
-          functions.compose-polygon-displacement($i) 0%,
-          functions.compose-polygon-displacement($i) 0%,
-          functions.compose-polygon-displacement($i) 0%,
-          0% 0%,
-          50% 50%
-        );
-    }
-  }
-
-  @for $j from 25 to 50 {
-    &[data-percentage="#{$j}"]::after {
-      clip-path:
-        polygon(
-          100% functions.compose-polygon-displacement($j),
-          100% functions.compose-polygon-displacement($j),
-          100% functions.compose-polygon-displacement($j),
-          100% 0%,
-          0% 0%,
-          50% 50%
-        );
-    }
-  }
-
-  @for $k from 50 to 75 {
-    &[data-percentage="#{$k}"]::after {
-      clip-path:
-        polygon(
-          (100% - functions.compose-polygon-displacement($k)) 100%,
-          (100% - functions.compose-polygon-displacement($k)) 100%,
-          100% 100%,
-          100% 0%,
-          0% 0%,
-          50% 50%
-        );
-    }
-  }
-
-  @for $l from 75 to 100 {
-    &[data-percentage="#{$l}"]::after {
-      clip-path:
-        polygon(
-          0% (100% - functions.compose-polygon-displacement($l)),
-          0 100%,
-          100% 100%,
-          100% 0%,
-          0% 0%,
-          50% 50%
-        );
+      --circular-progress-indicator-percentage: #{$i * 1%};
     }
   }
 

--- a/packages/progress-indicator/_mixins.scss
+++ b/packages/progress-indicator/_mixins.scss
@@ -49,29 +49,29 @@
   }
 }
 
-@property --circular-progress-indicator-start-point {
+@property --circular-start-point {
   syntax: "<percentage>";
   inherits: false;
   initial-value: 0%;
 }
 
-@property --circular-progress-indicator-percentage {
+@property --circular-percentage {
   syntax: "<percentage>";
   inherits: false;
   initial-value: 100%;
 }
 
 @mixin circular($option: variables.$default-option) {
-  --circular-progress-indicator-color: #{adapter.get-progress-indicator-indicator-surface-color()};
-  --circular-progress-indicator-size: #{adapter.get-progress-indicator-border-size($size: m)};
+  --circular-color: #{adapter.get-progress-indicator-indicator-surface-color()};
+  --circular-size: #{adapter.get-progress-indicator-border-size($size: m)};
 
   position: relative;
   width: adapter.get-circular-progress-indicator-width();
   height: adapter.get-circular-progress-indicator-height();
 
   &::after {
-    --circular-progress-indicator-start-point: 0%;
-    --circular-progress-indicator-percentage: 100%;
+    --circular-start-point: 0%;
+    --circular-percentage: 100%;
 
     position: absolute;
     inset: adapter.get-spacing-size($level: xxs);
@@ -80,27 +80,27 @@
     margin: auto;
     background:
       conic-gradient(
-        transparent var(--circular-progress-indicator-start-point),
-        var(--circular-progress-indicator-color) var(--circular-progress-indicator-start-point),
-        var(--circular-progress-indicator-color) var(--circular-progress-indicator-percentage),
+        transparent var(--circular-start-point),
+        var(--circular-color) var(--circular-start-point),
+        var(--circular-color) var(--circular-percentage),
         transparent 0
       );
     border-radius: 50%;
-    transition: --circular-progress-indicator-percentage 0.1s ease;
+    transition: --circular-percentage 0.1s ease;
     content: "";
     mask-image:
       radial-gradient(
         closest-side,
-        transparent calc(100% - var(--circular-progress-indicator-size) - 0.5px),
-        rgba(0, 0, 0, 50%) calc(100% - var(--circular-progress-indicator-size) - 0.25px),
-        black calc(100% - var(--circular-progress-indicator-size)) 100%
+        transparent calc(100% - var(--circular-size) - 0.5px),
+        rgba(0, 0, 0, 50%) calc(100% - var(--circular-size) - 0.25px),
+        black calc(100% - var(--circular-size)) 100%
       );
     aspect-ratio: 1;
   }
 
   &.-is-parent-color {
     &::after {
-      --circular-progress-indicator-color: currentcolor;
+      --circular-color: currentcolor;
     }
   }
 
@@ -112,7 +112,7 @@
 
   @for $i from 0 to 100 {
     &[data-percentage="#{$i}"]::after {
-      --circular-progress-indicator-percentage: #{$i * 1%};
+      --circular-percentage: #{$i * 1%};
     }
   }
 
@@ -170,24 +170,24 @@
 
 @keyframes circular-indeterminate {
   0% {
-    --circular-progress-indicator-start-point: 0%;
-    --circular-progress-indicator-percentage: 0%;
+    --circular-start-point: 0%;
+    --circular-percentage: 0%;
   }
 
   50% {
-    --circular-progress-indicator-start-point: 0%;
-    --circular-progress-indicator-percentage: 100%;
+    --circular-start-point: 0%;
+    --circular-percentage: 100%;
   }
 
   100% {
-    --circular-progress-indicator-start-point: 100%;
-    --circular-progress-indicator-percentage: 100%;
+    --circular-start-point: 100%;
+    --circular-percentage: 100%;
   }
 }
 
 @mixin -size-style($size) {
   &::after {
-    --circular-progress-indicator-size: #{adapter.get-progress-indicator-border-size($size)};
+    --circular-size: #{adapter.get-progress-indicator-border-size($size)};
   }
 }
 

--- a/packages/progress-indicator/_mixins.scss
+++ b/packages/progress-indicator/_mixins.scss
@@ -85,6 +85,7 @@
         transparent 0
       );
     border-radius: 50%;
+    // stylelint-disable-next-line custom-property-no-missing-var-function
     transition: --circular-percentage 0.1s ease;
     content: "";
     mask-image:

--- a/packages/progress-indicator/_mixins.scss
+++ b/packages/progress-indicator/_mixins.scss
@@ -49,6 +49,12 @@
   }
 }
 
+@property --circular-progress-indicator-start-point {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+
 @property --circular-progress-indicator-percentage {
   syntax: "<percentage>";
   inherits: false;
@@ -64,13 +70,20 @@
   height: adapter.get-circular-progress-indicator-height();
 
   &::after {
+    --circular-progress-indicator-start-point: 0%;
     --circular-progress-indicator-percentage: 100%;
 
     position: absolute;
     inset: adapter.get-spacing-size($level: xxs);
     display: block;
     box-sizing: border-box;
-    background: conic-gradient(var(--circular-progress-indicator-color) var(--circular-progress-indicator-percentage), transparent 0);
+    background:
+      conic-gradient(
+        transparent var(--circular-progress-indicator-start-point),
+        var(--circular-progress-indicator-color) var(--circular-progress-indicator-start-point),
+        var(--circular-progress-indicator-color) var(--circular-progress-indicator-percentage),
+        transparent 0
+      );
     border-radius: 50%;
     transition: --circular-progress-indicator-percentage 0.1s ease;
     content: "";
@@ -103,10 +116,8 @@
 
   &:not([aria-valuenow]),
   &[aria-valuenow=""] {
-    animation: circular-indeterminate-rotate 2s linear infinite;
-
     &::after {
-      animation: circular-indeterminate 2s linear infinite;
+      animation: circular-indeterminate 2s linear infinite, circular-indeterminate-rotate 2s linear infinite;
     }
   }
 }
@@ -157,135 +168,18 @@
 
 @keyframes circular-indeterminate {
   0% {
-    clip-path:
-      polygon(
-        functions.compose-polygon-displacement(10) 0%,
-        functions.compose-polygon-displacement(10) 0%,
-        functions.compose-polygon-displacement(10) 0%,
-        functions.compose-polygon-displacement(10) 0%,
-        0% 0%,
-        50% 50%
-      );
-  }
-
-  8% {
-    clip-path:
-      polygon(
-        100% 0%,
-        100% 0%,
-        100% 0%,
-        100% 0%,
-        0% 0%,
-        50% 50%
-      );
-  }
-
-  16% {
-    clip-path:
-      polygon(
-        100% 100%,
-        100% 100%,
-        100% 100%,
-        100% 0%,
-        0% 0%,
-        50% 50%
-      );
-  }
-
-  24% {
-    clip-path:
-      polygon(
-        0% 100%,
-        0 100%,
-        100% 100%,
-        100% 0%,
-        0% 0%,
-        50% 50%
-      );
-  }
-
-  32% {
-    clip-path:
-      polygon(
-        0% functions.compose-polygon-displacement(10),
-        0 100%,
-        100% 100%,
-        100% 0%,
-        0% 0%,
-        50% 50%
-      );
+    --circular-progress-indicator-start-point: 0%;
+    --circular-progress-indicator-percentage: 0%;
   }
 
   50% {
-    clip-path:
-      polygon(
-        0% 0%,
-        0% 100%,
-        100% 100%,
-        100% 0%,
-        functions.compose-polygon-displacement(10) 0%,
-        50% 50%
-      );
-  }
-
-  58% {
-    clip-path:
-      polygon(
-        0% 0%,
-        0% 100%,
-        100% 100%,
-        100% 0%,
-        100% 0%,
-        50% 50%
-      );
-  }
-
-  66% {
-    clip-path:
-      polygon(
-        0% 0%,
-        0% 100%,
-        100% 100%,
-        100% 100%,
-        100% 100%,
-        50% 50%
-      );
-  }
-
-  74% {
-    clip-path:
-      polygon(
-        0% 0%,
-        0% 100%,
-        0% 100%,
-        0% 100%,
-        0% 100%,
-        50% 50%
-      );
-  }
-
-  82% {
-    clip-path:
-      polygon(
-        0% 0%,
-        0% functions.compose-polygon-displacement(10),
-        0% functions.compose-polygon-displacement(10),
-        0% functions.compose-polygon-displacement(10),
-        0% functions.compose-polygon-displacement(10),
-        50% 50%
-      );
+    --circular-progress-indicator-start-point: 0%;
+    --circular-progress-indicator-percentage: 100%;
   }
 
   100% {
-    clip-path:
-      polygon(
-        functions.compose-polygon-displacement(10) 0%,
-        0% 0%,
-        0% 0%,
-        0% 0%,
-        0% 0%,
-        50% 50%
-      );
+    --circular-progress-indicator-start-point: 100%;
+    --circular-progress-indicator-percentage: 100%;
   }
 }
 

--- a/packages/progress-indicator/_mixins.scss
+++ b/packages/progress-indicator/_mixins.scss
@@ -57,6 +57,7 @@
 
 @mixin circular($option: variables.$default-option) {
   --circular-progress-indicator-color: #{adapter.get-progress-indicator-indicator-surface-color()};
+  --circular-progress-indicator-size: #{adapter.get-progress-indicator-border-size($size: m)};
 
   position: relative;
   width: adapter.get-circular-progress-indicator-width();
@@ -73,7 +74,13 @@
     border-radius: 50%;
     transition: --circular-progress-indicator-percentage 0.1s ease;
     content: "";
-    mask-image: radial-gradient(closest-side, transparent 79%, black 80% 100%);
+    mask-image:
+      radial-gradient(
+        closest-side,
+        transparent calc(100% - var(--circular-progress-indicator-size) - 0.5px),
+        rgba(0, 0, 0, 50%) calc(100% - var(--circular-progress-indicator-size) - 0.25px),
+        black calc(100% - var(--circular-progress-indicator-size)) 100%
+      );
   }
 
   &.-is-parent-color {
@@ -284,7 +291,7 @@
 
 @mixin -size-style($size) {
   &::after {
-    border-width: adapter.get-progress-indicator-border-size($size);
+    --circular-progress-indicator-size: #{adapter.get-progress-indicator-border-size($size)};
   }
 }
 

--- a/packages/progress-indicator/_mixins.scss
+++ b/packages/progress-indicator/_mixins.scss
@@ -3,7 +3,6 @@
 @use "@pepabo-inhouse/icon/mixins" as icon;
 @use "@pepabo-inhouse/adapter/functions" as adapter;
 @use "./variables";
-@use "./functions";
 
 @mixin linear($option: variables.$default-option) {
   $option: map.merge(variables.$default-option, $option);

--- a/packages/progress-indicator/_mixins.scss
+++ b/packages/progress-indicator/_mixins.scss
@@ -77,6 +77,7 @@
     inset: adapter.get-spacing-size($level: xxs);
     display: block;
     box-sizing: border-box;
+    margin: auto;
     background:
       conic-gradient(
         transparent var(--circular-progress-indicator-start-point),
@@ -94,6 +95,7 @@
         rgba(0, 0, 0, 50%) calc(100% - var(--circular-progress-indicator-size) - 0.25px),
         black calc(100% - var(--circular-progress-indicator-size)) 100%
       );
+    aspect-ratio: 1;
   }
 
   &.-is-parent-color {

--- a/packages/stories-web/src/circular-progress-indicator.stories.tsx
+++ b/packages/stories-web/src/circular-progress-indicator.stories.tsx
@@ -1,6 +1,7 @@
 import type { StoryFn, Meta } from '@storybook/react'
 import React from 'react'
 import Circular, { Props } from './components/progress-indicator/Circular'
+import Button from './components/button/Button'
 
 export default {
   title: 'Components/ProgressIndicator/Circular',
@@ -19,3 +20,29 @@ export const Indeterminate = Template.bind({})
 Indeterminate.args = {
   max: 100,
 }
+
+export const ButtonWithParentColor = Template.bind({})
+ButtonWithParentColor.args = {
+  max: 100,
+  isParentColor: true,
+}
+ButtonWithParentColor.decorators = [
+  (Story) => (
+    <div>
+      <Button
+        appearance="outlined"
+        color="interactive"
+        size="m"
+        width='half'
+        leading={<Story />}
+      />
+      <Button
+        appearance="filled"
+        color="interactive"
+        size="m"
+        width='half'
+        leading={<Story />}
+      />
+    </div>
+  ),
+]


### PR DESCRIPTION

<img width="810" height="464" alt="スクリーンショット 2025-10-03 15 25 37" src="https://github.com/user-attachments/assets/f194e901-d688-4ac5-b5d4-93b821a17cd9" />


### 削除されたファイル
- `packages/progress-indicator/_functions.scss` - ポリゴン変位計算用の関数ファイル
- `packages/progress-indicator/_functions.test.scss` - 関数のテストファイル

### ファイル変更

#### `packages/progress-indicator/_index.scss`
- エクスポートするmixinに `circular` を追加

#### `packages/progress-indicator/_mixins.scss`

##### 削除された内容
- `@use "./functions"` のインポート文
- 複雑な `clip-path` ベースの円形プログレス実装
- 25段階の複雑なポリゴン計算ロジック（4つの `@for` ループ）

##### 追加された内容
- CSS Custom Properties（CSS変数）の定義
  - `--circular-start-point`: 開始点のパーセンテージ
  - `--circular-percentage`: プログレスのパーセンテージ
- `conic-gradient` を使用した新しい円形プログレス実装
- `mask-image` を使用したリング形状の作成
- `aspect-ratio: 1` による正方形の強制

##### 実装方式の変更

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| 実装方式 | `clip-path` + ポリゴン計算 | `conic-gradient` + `mask-image` |
| パーセンテージ精度 | 25段階（4%刻み） | 100段階（1%刻み） |
| アニメーション | 複雑なポリゴン変形 | CSS変数の値変更 |
| コード量 | 約140行の複雑なロジック | 約20行のシンプルな実装 |

##### アニメーションの簡素化
- `circular-indeterminate` キーフレームを大幅に簡素化
- 複雑なポリゴン計算を削除し、CSS変数の値変更のみに変更

##### サイズ指定の変更
- `border-width` から `--circular-size` CSS変数に変更

#### `packages/stories-web/src/circular-progress-indicator.stories.tsx`

##### 追加された内容
- `Button` コンポーネントのインポート
- `ButtonWithParentColor` ストーリーの追加
  - 親要素の色を継承するプログレスインジケーター
  - アウトラインとフィルドの2つのボタンでデモ表示

<img width="807" height="63" alt="スクリーンショット 2025-10-03 15 25 14" src="https://github.com/user-attachments/assets/aa28819d-f7c3-49ff-9b53-68da169b58b2" />


### 技術的改善点
- **パフォーマンス向上**: 複雑なポリゴン計算を削除し、CSS変数とグラデーションを使用
- **保守性向上**: コード量を大幅に削減し、理解しやすい実装に変更
- **精度向上**: プログレス表示の精度を25段階から100段階に向上
- **モダンCSS活用**: `conic-gradient`、`mask-image`、`aspect-ratio` などのモダンCSS機能を活用