### PR TITLE
ラジオボタンの左端までのオフセットを取得するヘルパー関数を追加する

### DIFF
--- a/packages/adapter/functions/size/_gap.scss
+++ b/packages/adapter/functions/size/_gap.scss
@@ -27,3 +27,15 @@ $gap-size-tokens: map.get(
 
   @return map.get($tokens, $level);
 }
+
+/// radioボタンとラベル間のgapを取得します。
+///
+/// @group size
+/// @example
+///   functions.get-radio-label-gap()
+///   // 0.5rem
+@function get-radio-label-gap() {
+  // TODO: トークンが追加されたら以下を使用:
+  // @return map.get($gap-size-tokens, radio-label);
+  @return 0.5rem;
+}

--- a/packages/adapter/functions/size/_gap.test.scss
+++ b/packages/adapter/functions/size/_gap.test.scss
@@ -7,3 +7,10 @@
     1rem
   );
 }
+
+@function test-get-radio-label-gap() {
+  @return assert.equals(
+    functions.get-radio-label-gap(),
+    0.5rem
+  );
+}

--- a/packages/adapter/functions/size/_width.scss
+++ b/packages/adapter/functions/size/_width.scss
@@ -3,6 +3,7 @@
 @use "@pepabo-inhouse/flavor/tokens";
 @use "../helpers";
 @use "../../error-message";
+@use "./gap";
 
 $width-tokens: map.get(
   map.get(tokens.$tokens, size),
@@ -228,6 +229,17 @@ $width-tokens: map.get(
   $child-tokens: map.get($tokens, child);
 
   @return map.get($child-tokens, foreground);
+}
+
+/// radioボタンのラベル左端位置のオフセット値を取得します
+/// ラベル下に配置する要素の左端を揃える際に使用します
+///
+/// @group size
+/// @example
+///   functions.get-radio-label-offset()
+///   // 2rem
+@function get-radio-label-offset() {
+  @return get-radio-parent-width() + gap.get-radio-label-gap();
 }
 
 /// side navigationのwidthの値を取得します

--- a/packages/adapter/functions/size/_width.test.scss
+++ b/packages/adapter/functions/size/_width.test.scss
@@ -106,6 +106,13 @@
   );
 }
 
+@function test-get-radio-label-offset() {
+  @return assert.equals(
+    functions.get-radio-label-offset(),
+    2rem
+  );
+}
+
 @function test-get-side-navigation-width() {
   @return assert.equals(
     functions.get-side-navigation-width(),


### PR DESCRIPTION
ラジオボタンの直下に何らかのテキストを入れたくなることがあります。このとき、ラジオボタンの右端と位置がそろうようにspaceを入れたくなるのですが、それに関する定数値が公開されていない状態です。

これを公開するためのSass Functionを追加します。

まだデザイントークンとして定義されていないようなのですが、ある程度安定して利用されているなら、後続のタスクとしてトークン化もしてしまうといいかもしれません。