### PR TITLE
fix(adapter): 非推奨の Sass color 関数を color.channel に置換

### DIFF
--- a/packages/adapter/functions/_helpers.scss
+++ b/packages/adapter/functions/_helpers.scss
@@ -409,6 +409,8 @@
 }
 
 /// （未使用？）
+/// TODO: 自己再帰による無限ループと、Sass 1.85+ で非推奨の if() を含んでいる。
+/// 削除したいが、残っている理由があるのかもしれないので確認する。
 ///
 /// @group helper
 @function get-foreground-brightness($background-color) {

--- a/packages/adapter/functions/_helpers.scss
+++ b/packages/adapter/functions/_helpers.scss
@@ -470,9 +470,9 @@ $available-hexadecimal-chars: "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", 
 /// 輝度を計算する
 /// 参考: https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-tests
 @function -compose-luminance($color) {
-  $red: -compose-linear-channel-value(color.channel($color, "red"));
-  $green: -compose-linear-channel-value(color.channel($color, "green"));
-  $blue: -compose-linear-channel-value(color.channel($color, "blue"));
+  $red: -compose-linear-channel-value(color.channel($color, "red", $space: rgb));
+  $green: -compose-linear-channel-value(color.channel($color, "green", $space: rgb));
+  $blue: -compose-linear-channel-value(color.channel($color, "blue", $space: rgb));
 
   @return 0.2126 * $red + 0.7152 * $green + 0.0722 * $blue;
 }

--- a/packages/adapter/functions/_helpers.scss
+++ b/packages/adapter/functions/_helpers.scss
@@ -468,9 +468,9 @@ $available-hexadecimal-chars: "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", 
 /// 輝度を計算する
 /// 参考: https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-tests
 @function -compose-luminance($color) {
-  $red: -compose-linear-channel-value(color.red($color));
-  $green: -compose-linear-channel-value(color.green($color));
-  $blue: -compose-linear-channel-value(color.blue($color));
+  $red: -compose-linear-channel-value(color.channel($color, "red"));
+  $green: -compose-linear-channel-value(color.channel($color, "green"));
+  $blue: -compose-linear-channel-value(color.channel($color, "blue"));
 
   @return 0.2126 * $red + 0.7152 * $green + 0.0722 * $blue;
 }


### PR DESCRIPTION
## 背景

Sass 1.79+ で `color.red()` / `color.green()` / `color.blue()` が非推奨になりました。
`packages/adapter/functions/_helpers.scss` の `-compose-luminance` 関数内でこれらを使用しており、ビルド時に大量の警告が出ています。

`-compose-luminance` は adapter を `@use` しているコンポーネントのコンパイルごとに呼び出されるため、ログが大量に膨らみます。
Claude Code などの AI ツールを使いながら開発している場合、この大量出力がコンテキストウィンドウのトークンを消費するという問題もあります。

また、Sass 2.0 ではこれらの関数が削除されるため、現状は警告ですが将来的にビルドエラーになります。（[ref](https://sass-lang.com/documentation/breaking-changes/color-functions/)）

## 変更内容

`-compose-luminance` 関数内の3行を置換：

```scss
// Before
$red: -compose-linear-channel-value(color.red($color));
$green: -compose-linear-channel-value(color.green($color));
$blue: -compose-linear-channel-value(color.blue($color));

// After
$red: -compose-linear-channel-value(color.channel($color, "red", $space: rgb));
$green: -compose-linear-channel-value(color.channel($color, "green", $space: rgb));
$blue: -compose-linear-channel-value(color.channel($color, "blue", $space: rgb));
```

`color.channel()` は Sass の移行ガイドで推奨されている代替手段です。`$space: rgb` を明示することで、旧 API（`color.red()` 等）と同じく sRGB の各チャンネル値（0〜255）を返します。（[ref](https://arc.net/l/quote/uwlbhxhq)）

## 別途確認したいこと

`get-foreground-brightness` 関数に TODO コメントを追加しました。
自己再帰による無限ループと Sass 1.85+ で非推奨の `if()` を含んでいます。
削除したいのですが、残っている理由がありそうなので、削除前に確認した方が良さそうと思いました。
残っている理由は何ですか？