### PR TITLE
buttonの全variantがループしてcssへ出力されないようにmixinを調整

### DIFF
--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -11,3 +11,56 @@ $ npm install @pepabo-inhouse/button
 
 $ yarn add @pepabo-inhouse/button
 ```
+
+### Mixins
+
+#### `style($options: null)`
+
+ボタンのスタイルを出力します。`$options` の指定の有無で出力される内容が変わります。
+
+- `$options` を省略した場合は、デフォルトのスタイルに加えてすべてのmodifier（`-appearance-*`, `-color-*`, `-brightness-*`, `-shape-*`, `-size-*`, `-width-*`）のスタイルを出力します。`export` が出力する `.in-button` と同じ内容です。
+- `$options` を明示的に指定した場合は、指定した値（未指定の属性はデフォルト値）のスタイルだけを出力し、modifierのスタイルは出力しません。mixinベース（エイリアシング）でスタイルを固定して使う場合は、こちらの使い方をすることで不要なCSSの出力を避けられます。
+
+```scss
+@use '@pepabo-inhouse/components-web' as inhouse;
+
+// 指定したオプションの組み合わせのスタイルだけが出力される
+.button-submit {
+  @include inhouse.button-style(
+    $options: (
+      appearance: flat,
+      color: neutral,
+      shape: circle,
+      size: m,
+      width: auto,
+    )
+  );
+}
+
+// 従来どおり、デフォルトのスタイルとすべてのmodifierのスタイルが出力される
+.button-legacy {
+  @include inhouse.button-style;
+}
+```
+
+#### `skeleton-style($options: null)`
+
+スケルトンボタンのスタイルを出力します。`style` と同様に、`$options` を省略した場合はすべてのmodifier（`-shape-*`, `-size-*`, `-width-*`）のスタイルを、明示的に指定した場合は指定した値（未指定の属性はデフォルト値）のスタイルだけを出力します。
+
+#### `style-with-variants($variants: (), $default-style: ...)`
+
+デフォルトのスタイルと、`$variants` で指定した属性・値の組み合わせをmodifierとして出力します。modifierとして利用したい値を絞りたい場合に使います。
+
+```scss
+@use '@pepabo-inhouse/button' as button;
+
+.my-button {
+  @include button.style-with-variants(
+    $variants: (
+      appearance: (flat, solid),
+      color: (primary, neutral),
+      size: (m, l)
+    )
+  );
+}
+```

--- a/packages/button/_mixins.scss
+++ b/packages/button/_mixins.scss
@@ -19,18 +19,25 @@
 /* stylelint-disable no-descending-specificity */
 /* stylelint-disable no-duplicate-selectors */
 
-@mixin style($options: variables.$default-option) {
-  @include style-with-variants(
-    $variants: (
-      appearance: adapter.get-button-appearances(),
-      color: adapter.get-button-colors(),
-      brightness: adapter.get-brightnesses(),
-      shape: adapter.get-shapes(),
-      size: adapter.get-interactive-component-height-keys(),
-      width: adapter.get-widths()
-    ),
-    $default-style: $options
-  );
+@mixin style($options: null) {
+  @if $options == null {
+    @include style-with-variants(
+      $variants: (
+        appearance: adapter.get-button-appearances(),
+        color: adapter.get-button-colors(),
+        brightness: adapter.get-brightnesses(),
+        shape: adapter.get-shapes(),
+        size: adapter.get-interactive-component-height-keys(),
+        width: adapter.get-widths()
+      ),
+      $default-style: variables.$default-option
+    );
+  } @else {
+    @include style-with-variants(
+      $variants: (),
+      $default-style: $options
+    );
+  }
 }
 
 /// 指定した属性とその値の組み合わせのスタイル
@@ -230,7 +237,15 @@
   }
 }
 
-@mixin skeleton-style($options: variables.$default-option) {
+@mixin skeleton-style($options: null) {
+  @if $options == null {
+    @include -skeleton-style-with-variants;
+  } @else {
+    @include -skeleton-proto($options);
+  }
+}
+
+@mixin -skeleton-proto($options) {
   $options: map.merge(variables.$default-option, $options);
 
   @include skeleton.style;
@@ -242,6 +257,12 @@
       $shape: map.get($options, shape),
       $size: map.get($options, size)
     );
+}
+
+@mixin -skeleton-style-with-variants {
+  $options: variables.$default-option;
+
+  @include -skeleton-proto($options);
 
   @each $shape in adapter.get-shapes() {
     &.-shape-#{$shape} {


### PR DESCRIPTION
mixinベースのスタイリング（エイリアシング）でボタンを使う際に、`$options` で指定した値のスタイルだけをCSSに出力するように `style` mixinを調整しました。

## 背景・課題

[READMEで推奨しているエイリアシング](https://github.com/pepabo/inhouse-components-web#development-philosophy)の使い方で、

```scss
.button-submit {
  @include inhouse.button-style(
    $options: (
      appearance: flat,
      color: neutral,
      shape: circle,
      size: m,
      width: auto,
    )
  );
}
```

と書いても、従来の実装では指定した `size: m` 以外の `s` や `xl`、`appearance` や `color` の他の値まで、すべてのvariantをループして `.button-submit` に対して出力していました（1回の `@include` で約1000ルールセット）。エイリアシングではオプションを固定して使うことが多くの比重を占めるはずで、modifier用のスタイル（mixinベースでのエイリアシングでスタイリングしたinhouse buttonに対して`-size-l`などclassベースのオプション指定を追加すること）は実質的に不要なCSSになっていると言えます。

## 変更内容

- `style` の引数のデフォルトを `$options: null` に変更し、挙動を分岐
  - `$options` 省略時: 従来どおり、デフォルトのスタイル + すべてのmodifier（`-appearance-*`, `-color-*` など）のスタイルを出力（`export` = `.in-button` はこのパターンです）
  - `$options` 指定時: 指定した値（未指定の属性はデフォルト値）のスタイルだけを出力し、modifierのスタイルは出力しない（上記の例では9ルールセットになる）
- `skeleton-style` にも同じ扱いを適用
- 使い方をbuttonパッケージのREADMEに追記

## 互換性

- classベース: `export`（`.in-button` / `.in-skeleton-button`）の出力は変更前後で同じでした（コンパイル結果をdiffで確認した）
- mixinベース: `style` / `style-with-variants` のシグネチャは変わらなくて、引数なしの `@include button.style` も従来と同一の出力でした。
- 唯一出力が変わるのは `.in-callout` 配下です。calloutが内部で `button.style($options: (size: $size, appearance: transparent))` を呼んでいて、そこに展開されていた未使用のボタン全variant（3,716ルールセット）が出力されなくなります（`.in-callout ._action` にmodifierを当てる使い方はドキュメント・リポジトリ内に存在しないことを確認してます）。この結果としてビルド済みCSS全体は45,191行 → 18,015行に削減されるようです。

動作確認は

- `npm test`（sassunit 全パッケージ）: passed / failed: 0
- `npm run lint:style`: エラーなし
- `inhouse-components-web.scss` のコンパイル結果の変更前後diffで、上記callout以外に差分がないことを確認
- design.pepabo.com から本ブランチのパッケージをローカル参照（`file:`）して、サイト全体の表示・アイコンフォント・GlobalHeaderなどの `button.style($options...)` 利用箇所に影響がないことを確認

などを行いましたが、レビュワーはローカルで別プロジェクトへこのbranchのinhouse buttonをインストールして表示の変わり映えがないか・その上でコードが削減されているかなど確認してみてください。

## 補足

chip や sticker など他のパッケージにも全variantを無条件にループする同様の実装がありますが、まず使用頻度とvariantの数の多さゆえ最もCSSの削減が効果的と考えられるbuttonのみ対応してます。